### PR TITLE
Delete mock #dispose generated by CIG

### DIFF
--- a/src/SDL3/SDL3AsyncIO.class.st
+++ b/src/SDL3/SDL3AsyncIO.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3AsyncIO >> dispose [
-
-	self ffiCall: #(void SDL_AsyncIO_dispose(SDL_AsyncIO* self))
-]

--- a/src/SDL3/SDL3AsyncIOQueue.class.st
+++ b/src/SDL3/SDL3AsyncIOQueue.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3AsyncIOQueue >> dispose [
-
-	self ffiCall: #(void SDL_AsyncIOQueue_dispose(SDL_AsyncIOQueue* self))
-]

--- a/src/SDL3/SDL3AudioStream.class.st
+++ b/src/SDL3/SDL3AudioStream.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3AudioStream >> dispose [
-
-	self ffiCall: #(void SDL_AudioStream_dispose(SDL_AudioStream* self))
-]

--- a/src/SDL3/SDL3BaseObject.class.st
+++ b/src/SDL3/SDL3BaseObject.class.st
@@ -19,8 +19,7 @@ SDL3BaseObject >> autoRelease [
 
 { #category : 'finalization' }
 SDL3BaseObject >> dispose [
-	
-	self subclassResponsibility
+	"Hook sent on finalization"
 ]
 
 { #category : 'finalization' }

--- a/src/SDL3/SDL3Camera.class.st
+++ b/src/SDL3/SDL3Camera.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Camera >> dispose [
-
-	self ffiCall: #(void SDL_Camera_dispose(SDL_Camera* self))
-]

--- a/src/SDL3/SDL3Condition.class.st
+++ b/src/SDL3/SDL3Condition.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Condition >> dispose [
-
-	self ffiCall: #(void SDL_Condition_dispose(SDL_Condition* self))
-]

--- a/src/SDL3/SDL3Cursor.class.st
+++ b/src/SDL3/SDL3Cursor.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Cursor >> dispose [
-
-	self ffiCall: #(void SDL_Cursor_dispose(SDL_Cursor* self))
-]

--- a/src/SDL3/SDL3DisplayModeData.class.st
+++ b/src/SDL3/SDL3DisplayModeData.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3DisplayModeData >> dispose [
-
-	self ffiCall: #(void SDL_DisplayModeData_dispose(SDL_DisplayModeData* self))
-]

--- a/src/SDL3/SDL3Environment.class.st
+++ b/src/SDL3/SDL3Environment.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Environment >> dispose [
-
-	self ffiCall: #(void SDL_Environment_dispose(SDL_Environment* self))
-]

--- a/src/SDL3/SDL3GLContextState.class.st
+++ b/src/SDL3/SDL3GLContextState.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GLContextState >> dispose [
-
-	self ffiCall: #(void SDL_GLContextState_dispose(SDL_GLContextState* self))
-]

--- a/src/SDL3/SDL3GPUBuffer.class.st
+++ b/src/SDL3/SDL3GPUBuffer.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUBuffer >> dispose [
-
-	self ffiCall: #(void SDL_GPUBuffer_dispose(SDL_GPUBuffer* self))
-]

--- a/src/SDL3/SDL3GPUCommandBuffer.class.st
+++ b/src/SDL3/SDL3GPUCommandBuffer.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUCommandBuffer >> dispose [
-
-	self ffiCall: #(void SDL_GPUCommandBuffer_dispose(SDL_GPUCommandBuffer* self))
-]

--- a/src/SDL3/SDL3GPUComputePass.class.st
+++ b/src/SDL3/SDL3GPUComputePass.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUComputePass >> dispose [
-
-	self ffiCall: #(void SDL_GPUComputePass_dispose(SDL_GPUComputePass* self))
-]

--- a/src/SDL3/SDL3GPUComputePipeline.class.st
+++ b/src/SDL3/SDL3GPUComputePipeline.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUComputePipeline >> dispose [
-
-	self ffiCall: #(void SDL_GPUComputePipeline_dispose(SDL_GPUComputePipeline* self))
-]

--- a/src/SDL3/SDL3GPUCopyPass.class.st
+++ b/src/SDL3/SDL3GPUCopyPass.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUCopyPass >> dispose [
-
-	self ffiCall: #(void SDL_GPUCopyPass_dispose(SDL_GPUCopyPass* self))
-]

--- a/src/SDL3/SDL3GPUDevice.class.st
+++ b/src/SDL3/SDL3GPUDevice.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUDevice >> dispose [
-
-	self ffiCall: #(void SDL_GPUDevice_dispose(SDL_GPUDevice* self))
-]

--- a/src/SDL3/SDL3GPUFence.class.st
+++ b/src/SDL3/SDL3GPUFence.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUFence >> dispose [
-
-	self ffiCall: #(void SDL_GPUFence_dispose(SDL_GPUFence* self))
-]

--- a/src/SDL3/SDL3GPUGraphicsPipeline.class.st
+++ b/src/SDL3/SDL3GPUGraphicsPipeline.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUGraphicsPipeline >> dispose [
-
-	self ffiCall: #(void SDL_GPUGraphicsPipeline_dispose(SDL_GPUGraphicsPipeline* self))
-]

--- a/src/SDL3/SDL3GPURenderPass.class.st
+++ b/src/SDL3/SDL3GPURenderPass.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPURenderPass >> dispose [
-
-	self ffiCall: #(void SDL_GPURenderPass_dispose(SDL_GPURenderPass* self))
-]

--- a/src/SDL3/SDL3GPURenderState.class.st
+++ b/src/SDL3/SDL3GPURenderState.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPURenderState >> dispose [
-
-	self ffiCall: #(void SDL_GPURenderState_dispose(SDL_GPURenderState* self))
-]

--- a/src/SDL3/SDL3GPUSampler.class.st
+++ b/src/SDL3/SDL3GPUSampler.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUSampler >> dispose [
-
-	self ffiCall: #(void SDL_GPUSampler_dispose(SDL_GPUSampler* self))
-]

--- a/src/SDL3/SDL3GPUShader.class.st
+++ b/src/SDL3/SDL3GPUShader.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUShader >> dispose [
-
-	self ffiCall: #(void SDL_GPUShader_dispose(SDL_GPUShader* self))
-]

--- a/src/SDL3/SDL3GPUTexture.class.st
+++ b/src/SDL3/SDL3GPUTexture.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUTexture >> dispose [
-
-	self ffiCall: #(void SDL_GPUTexture_dispose(SDL_GPUTexture* self))
-]

--- a/src/SDL3/SDL3GPUTransferBuffer.class.st
+++ b/src/SDL3/SDL3GPUTransferBuffer.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3GPUTransferBuffer >> dispose [
-
-	self ffiCall: #(void SDL_GPUTransferBuffer_dispose(SDL_GPUTransferBuffer* self))
-]

--- a/src/SDL3/SDL3IOStream.class.st
+++ b/src/SDL3/SDL3IOStream.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3IOStream >> dispose [
-
-	self ffiCall: #(void SDL_IOStream_dispose(SDL_IOStream* self))
-]

--- a/src/SDL3/SDL3IconvDataT.class.st
+++ b/src/SDL3/SDL3IconvDataT.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3IconvDataT >> dispose [
-
-	self ffiCall: #(void SDL_iconv_data_t_dispose(SDL_iconv_data_t* self))
-]

--- a/src/SDL3/SDL3Joystick.class.st
+++ b/src/SDL3/SDL3Joystick.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Joystick >> dispose [
-
-	self ffiCall: #(void SDL_Joystick_dispose(SDL_Joystick* self))
-]

--- a/src/SDL3/SDL3Mutex.class.st
+++ b/src/SDL3/SDL3Mutex.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Mutex >> dispose [
-
-	self ffiCall: #(void SDL_Mutex_dispose(SDL_Mutex* self))
-]

--- a/src/SDL3/SDL3RWLock.class.st
+++ b/src/SDL3/SDL3RWLock.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3RWLock >> dispose [
-
-	self ffiCall: #(void SDL_RWLock_dispose(SDL_RWLock* self))
-]

--- a/src/SDL3/SDL3Renderer.class.st
+++ b/src/SDL3/SDL3Renderer.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Renderer >> dispose [
-
-	self ffiCall: #(void SDL_Renderer_dispose(SDL_Renderer* self))
-]

--- a/src/SDL3/SDL3Semaphore.class.st
+++ b/src/SDL3/SDL3Semaphore.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Semaphore >> dispose [
-
-	self ffiCall: #(void SDL_Semaphore_dispose(SDL_Semaphore* self))
-]

--- a/src/SDL3/SDL3Sensor.class.st
+++ b/src/SDL3/SDL3Sensor.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Sensor >> dispose [
-
-	self ffiCall: #(void SDL_Sensor_dispose(SDL_Sensor* self))
-]

--- a/src/SDL3/SDL3SharedObject.class.st
+++ b/src/SDL3/SDL3SharedObject.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3SharedObject >> dispose [
-
-	self ffiCall: #(void SDL_SharedObject_dispose(SDL_SharedObject* self))
-]

--- a/src/SDL3/SDL3Thread.class.st
+++ b/src/SDL3/SDL3Thread.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Thread >> dispose [
-
-	self ffiCall: #(void SDL_Thread_dispose(SDL_Thread* self))
-]

--- a/src/SDL3/SDL3Tray.class.st
+++ b/src/SDL3/SDL3Tray.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Tray >> dispose [
-
-	self ffiCall: #(void SDL_Tray_dispose(SDL_Tray* self))
-]

--- a/src/SDL3/SDL3TrayEntry.class.st
+++ b/src/SDL3/SDL3TrayEntry.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3TrayEntry >> dispose [
-
-	self ffiCall: #(void SDL_TrayEntry_dispose(SDL_TrayEntry* self))
-]

--- a/src/SDL3/SDL3TrayMenu.class.st
+++ b/src/SDL3/SDL3TrayMenu.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3TrayMenu >> dispose [
-
-	self ffiCall: #(void SDL_TrayMenu_dispose(SDL_TrayMenu* self))
-]

--- a/src/SDL3/SDL3Window.class.st
+++ b/src/SDL3/SDL3Window.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3Window >> dispose [
-
-	self ffiCall: #(void SDL_Window_dispose(SDL_Window* self))
-]

--- a/src/SDL3/SDL3XEvent.class.st
+++ b/src/SDL3/SDL3XEvent.class.st
@@ -5,9 +5,3 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
-
-{ #category : 'finalizing' }
-SDL3XEvent >> dispose [
-
-	self ffiCall: #(void _XEvent_dispose(_XEvent* self))
-]


### PR DESCRIPTION
For now we destroy and free the SDL objects "manually".