### PR TITLE
Tray API

### DIFF
--- a/src/SDL3-API/SDL3Tray.extension.st
+++ b/src/SDL3-API/SDL3Tray.extension.st
@@ -1,0 +1,31 @@
+Extension { #name : 'SDL3Tray' }
+
+{ #category : '*SDL3-API' }
+SDL3Tray >> destroy [
+
+	^ self ffiLibrary destroyTray: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3Tray >> icon: icon [
+
+	^ self ffiLibrary setTrayIconTray: self icon: icon
+]
+
+{ #category : '*SDL3-API' }
+SDL3Tray >> menu [
+
+	^ self ffiLibrary getTrayMenu: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3Tray >> newMenu [
+
+	^ self ffiLibrary newTrayMenu: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3Tray >> tooltip: tooltip [
+
+	^ self ffiLibrary setTrayTooltipTray: self tooltip: tooltip
+]

--- a/src/SDL3-API/SDL3TrayEntry.extension.st
+++ b/src/SDL3-API/SDL3TrayEntry.extension.st
@@ -1,0 +1,76 @@
+Extension { #name : 'SDL3TrayEntry' }
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> callback: callback userdata: userdata [
+
+	^ self ffiLibrary
+		  setTrayEntryCallbackEntry: self
+		  callback: callback
+		  userdata: userdata
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> checked [
+
+	^ self ffiLibrary getTrayEntryChecked: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> checked: checked [
+
+	^ self ffiLibrary setTrayEntryCheckedEntry: self checked: checked
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> click [
+
+	^ self ffiLibrary clickTrayEntry: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> enabled [
+
+	^ self ffiLibrary getTrayEntryEnabled: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> enabled: enabled [
+
+	^ self ffiLibrary setTrayEntryEnabledEntry: self enabled: enabled
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> label [
+
+	^ self ffiLibrary getTrayEntryLabel: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> label: label [
+
+	^ self ffiLibrary setTrayEntryLabelEntry: self label: label
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> newTraySubmenu [
+
+	^ self ffiLibrary newTraySubmenu: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> parent [
+
+	^ self ffiLibrary getTrayEntryParent: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> remove [
+
+	^ self ffiLibrary removeTrayEntry: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayEntry >> traySubmenu [
+
+	^ self ffiLibrary getTraySubmenu: self
+]

--- a/src/SDL3-API/SDL3TrayEntry.extension.st
+++ b/src/SDL3-API/SDL3TrayEntry.extension.st
@@ -52,7 +52,7 @@ SDL3TrayEntry >> label: label [
 ]
 
 { #category : '*SDL3-API' }
-SDL3TrayEntry >> newTraySubmenu [
+SDL3TrayEntry >> newSubmenu [
 
 	^ self ffiLibrary newTraySubmenu: self
 ]
@@ -70,7 +70,7 @@ SDL3TrayEntry >> remove [
 ]
 
 { #category : '*SDL3-API' }
-SDL3TrayEntry >> traySubmenu [
+SDL3TrayEntry >> submenu [
 
 	^ self ffiLibrary getTraySubmenu: self
 ]

--- a/src/SDL3-API/SDL3TrayMenu.extension.st
+++ b/src/SDL3-API/SDL3TrayMenu.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : 'SDL3TrayMenu' }
 
 { #category : '*SDL3-API' }
-SDL3TrayMenu >> getTrayEntriesIntoCount: count [
+SDL3TrayMenu >> getEntriesIntoCount: count [
 
 	^ self ffiLibrary getTrayEntriesMenu: self count: count
 ]
 
 { #category : '*SDL3-API' }
-SDL3TrayMenu >> insertTrayEntryAtPos: pos label: label flags: flags [
+SDL3TrayMenu >> insertEntryAt: pos label: label flags: flags [
 
 	^ self ffiLibrary
 		  insertTrayEntryAtMenu: self

--- a/src/SDL3-API/SDL3TrayMenu.extension.st
+++ b/src/SDL3-API/SDL3TrayMenu.extension.st
@@ -1,0 +1,29 @@
+Extension { #name : 'SDL3TrayMenu' }
+
+{ #category : '*SDL3-API' }
+SDL3TrayMenu >> getTrayEntriesIntoCount: count [
+
+	^ self ffiLibrary getTrayEntriesMenu: self count: count
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayMenu >> insertTrayEntryAtPos: pos label: label flags: flags [
+
+	^ self ffiLibrary
+		  insertTrayEntryAtMenu: self
+		  pos: pos
+		  label: label
+		  flags: flags
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayMenu >> parentEntry [
+
+	^ self ffiLibrary getTrayMenuParentEntry: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3TrayMenu >> parentTray [
+
+	^ self ffiLibrary getTrayMenuParentTray: self
+]

--- a/src/SDL3-Own/SDL3BaseObject.extension.st
+++ b/src/SDL3-Own/SDL3BaseObject.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'SDL3BaseObject' }
+
+{ #category : '*SDL3-Own' }
+SDL3BaseObject >> = anObject [
+	"Equality relies on the handle in the opaque external objects"
+
+	^ self class == anObject class and: [
+		self getHandle = anObject getHandle ]
+]
+
+{ #category : '*SDL3-Own' }
+SDL3BaseObject >> hash [
+
+	^ self class hash bitXor: self getHandle hash
+]

--- a/src/SDL3-Own/SDL3TrayEntryFlags.class.st
+++ b/src/SDL3-Own/SDL3TrayEntryFlags.class.st
@@ -1,0 +1,82 @@
+"
+Bindings for `SDL_TrayEntryFlags` constants in `SDL_tray.h`, in SDL3 3.2.10.
+
+This class isn't generated automatically, it's manual. Why? SDL3 doesn't define these flags as an enumeration but as `#define` macros.
+
+```
+/**
+ * Flags that control the creation of system tray entries.
+ *
+ * Some of these flags are required; exactly one of them must be specified at
+ * the time a tray entry is created. Other flags are optional; zero or more of
+ * those can be OR'ed together with the required flag.
+ *
+ * \since This datatype is available since SDL 3.2.0.
+ *
+ * \sa SDL_InsertTrayEntryAt
+ */
+typedef Uint32 SDL_TrayEntryFlags;
+
+#define SDL_TRAYENTRY_BUTTON      0x00000001u /**< Make the entry a simple button. Required. */
+#define SDL_TRAYENTRY_CHECKBOX    0x00000002u /**< Make the entry a checkbox. Required. */
+#define SDL_TRAYENTRY_SUBMENU     0x00000004u /**< Prepare the entry to have a submenu. Required */
+#define SDL_TRAYENTRY_DISABLED    0x80000000u /**< Make the entry disabled. Optional. */
+#define SDL_TRAYENTRY_CHECKED     0x40000000u /**< Make the entry checked. This is valid only for checkboxes. Optional. */
+```
+"
+Class {
+	#name : 'SDL3TrayEntryFlags',
+	#superclass : 'SDL3MacroDefinedFlag',
+	#classVars : [
+		'SDL_TRAYENTRY_BUTTON',
+		'SDL_TRAYENTRY_CHECKBOX',
+		'SDL_TRAYENTRY_CHECKED',
+		'SDL_TRAYENTRY_DISABLED',
+		'SDL_TRAYENTRY_SUBMENU'
+	],
+	#category : 'SDL3-Own',
+	#package : 'SDL3-Own'
+}
+
+{ #category : 'accessing enum' }
+SDL3TrayEntryFlags class >> button [
+	"This method was automatically generated"
+	^ SDL_TRAYENTRY_BUTTON
+]
+
+{ #category : 'accessing enum' }
+SDL3TrayEntryFlags class >> checkbox [
+	"This method was automatically generated"
+	^ SDL_TRAYENTRY_CHECKBOX
+]
+
+{ #category : 'accessing enum' }
+SDL3TrayEntryFlags class >> checked [
+	"This method was automatically generated"
+	^ SDL_TRAYENTRY_CHECKED
+]
+
+{ #category : 'accessing enum' }
+SDL3TrayEntryFlags class >> disabled [
+	"This method was automatically generated"
+	^ SDL_TRAYENTRY_DISABLED
+]
+
+{ #category : 'enum declaration' }
+SDL3TrayEntryFlags class >> enumDecl [
+	"self initializeEnumeration; rebuildEnumAccessors"
+	
+	^ #(
+		SDL_TRAYENTRY_BUTTON   1
+		SDL_TRAYENTRY_CHECKBOX 2
+		SDL_TRAYENTRY_SUBMENU  4
+		SDL_TRAYENTRY_DISABLED 2147483648
+		SDL_TRAYENTRY_CHECKED  1073741824
+		)
+]
+
+{ #category : 'accessing enum' }
+SDL3TrayEntryFlags class >> submenu [
+	"This method was automatically generated"
+	^ SDL_TRAYENTRY_SUBMENU
+]

--- a/src/SDL3-Own/SDL3TrayMenu.extension.st
+++ b/src/SDL3-Own/SDL3TrayMenu.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'SDL3TrayMenu' }
+
+{ #category : '*SDL3-Own' }
+SDL3TrayMenu >> entries [
+	"Answer an array of entries in the menu, in order."
+
+	| countBuffer first count array |
+	countBuffer := FFIInt32 newBuffer.
+	first := (self getEntriesIntoCount: countBuffer) getHandle.
+	count := countBuffer int32AtOffset: 0.
+	array := first readStructArrayFromPointers: SDL3TrayEntry size: count.
+	"Note: We do not free the returned array because we aren't the owners"
+	^ array
+]

--- a/src/SDL3-Tests/SDL3Demo.class.st
+++ b/src/SDL3-Tests/SDL3Demo.class.st
@@ -451,17 +451,57 @@ SDL3Demo class >> example08TrayMenu [
 
 	quit := false.
 	logs := LinkedList new.
-	logs add: 'Click on this window to enable/disable the system tray (with Pharo icon).'.
 
-	strings := #('One' 'Two' 'Three' 'Four' 'Five').
-	callback :=
-		FFICallback
-			signature: #(void (void *userdata, SDL3TrayEntry *entryHandle)) "SDL3TrayEntry"
-			block: [ :userdata :entryHandle |
-				| entry |
-				entry := SDL3TrayEntry fromHandle: entryHandle.
-				logs add: 'Clicked on ', entry label.
-				entry remove ].
+	[	| iconSurface menu submenu |
+		strings := #('One' 'Two' 'Three' 'Four' 'Five').
+		callback :=
+			FFICallback
+				signature: #(void (void *userdata, SDL3TrayEntry *entryHandle))
+				block: [ :userdata :entryHandle |
+					| entry |
+					entry := SDL3TrayEntry fromHandle: entryHandle.
+					logs add: 'Click on ', entry label surroundedBySingleQuotes ].
+
+		iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
+		tray := sdl newTrayIcon: iconSurface tooltip: 'PharoSDL3'.
+		iconSurface destroy.
+
+		menu := tray newMenu.
+
+		"Add submenu with buttons"
+		submenu :=
+			(menu
+				insertEntryAt: -1
+					label: 'Buttons'
+					flags: SDL3TrayEntryFlags submenu)
+				assertNotNullReturn;
+				newSubmenu.
+		strings do: [ :each |
+			(submenu
+				insertEntryAt: -1
+					label: 'Button ', each
+					flags: SDL3TrayEntryFlags button)
+				assertNotNullReturn;
+				callback: callback userdata: nil ].
+
+		"Add submenu with checkboxes"
+		submenu :=
+			(menu
+				insertEntryAt: -1
+					label: 'Checkboxes'
+					flags: SDL3TrayEntryFlags submenu)
+				assertNotNullReturn;
+				newSubmenu.
+		strings do: [ :each |
+			(submenu
+				insertEntryAt: -1
+					label: 'Checkbox ', each
+					flags: SDL3TrayEntryFlags checkbox)
+				assertNotNullReturn;
+				callback: callback userdata: nil ].
+
+		logs add: 'Click on this window to enable/disable the system tray (with Pharo icon).'.
+		] value.
 
 	"main loop"
 	[ quit ] whileFalse: [
@@ -471,32 +511,7 @@ SDL3Demo class >> example08TrayMenu [
 			evt type = SDL3EventType quit
 				ifTrue: [ quit := true ].
 			evt type = SDL3EventType windowCloseRequested
-				ifTrue: [ quit := true ].
-			evt type = SDL3EventType mouseButtonDown
-				ifTrue: [
-					tray
-						ifNil: [
-							| iconSurface menu entry |
-							iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
-							tray := sdl newTrayIcon: iconSurface tooltip: 'PharoSDL3'.
-
-							menu := tray newMenu.
-							strings do: [ :each |
-								entry :=
-									menu
-										insertTrayEntryAtPos: -1
-										label: each
-										flags: SDL3TrayEntryFlags button.
-								entry assertNotNullReturn.
-								entry
-									callback: callback
-									userdata: nil.
-								iconSurface destroy ].
-							 ]
-						ifNotNil: [
-							"tray destroy.
-							tray := nil" ] ]
-			].
+				ifTrue: [ quit := true ] ].
 		
 		"Render frame"
 		demo clearColor: Color blue muchDarker.

--- a/src/SDL3-Tests/SDL3Demo.class.st
+++ b/src/SDL3-Tests/SDL3Demo.class.st
@@ -440,7 +440,7 @@ SDL3Demo class >> example08TrayMenu [
 	Example:
 		./pharo Pharo.image eval --no-quit 'SDL3Demo example08TrayMenu' "
 
-	| demo quit logs sdl tray callback strings |
+	| demo quit logs sdl tray logEntryLabelCallback strings |
 	self
 		assert: (SDL2 wasInit: 16384) = 0 "SDL_INIT_EVENTS"
 		description: 'SDL2 is already initialized'.
@@ -452,9 +452,10 @@ SDL3Demo class >> example08TrayMenu [
 	quit := false.
 	logs := LinkedList new.
 
+	"TO DO: Extract to a demo class! the set up is in the following block closure:"
 	[	| iconSurface menu submenu |
 		strings := #('One' 'Two' 'Three' 'Four' 'Five').
-		callback :=
+		logEntryLabelCallback :=
 			FFICallback
 				signature: #(void (void *userdata, SDL3TrayEntry *entryHandle))
 				block: [ :userdata :entryHandle |
@@ -468,6 +469,20 @@ SDL3Demo class >> example08TrayMenu [
 
 		menu := tray newMenu.
 
+		"Basic: Add a button that is disabled and doesn't have a callback"
+		(menu
+			insertEntryAt: -1
+				label: 'Disabled button'
+				flags: SDL3TrayEntryFlags button | SDL3TrayEntryFlags disabled)
+			assertNotNullReturn.
+
+		"Add separator"
+		(menu
+			insertEntryAt: -1
+				label: nil
+				flags: SDL3TrayEntryFlags button)
+			assertNotNullReturn.
+				
 		"Add submenu with buttons"
 		submenu :=
 			(menu
@@ -482,7 +497,7 @@ SDL3Demo class >> example08TrayMenu [
 					label: 'Button ', each
 					flags: SDL3TrayEntryFlags button)
 				assertNotNullReturn;
-				callback: callback userdata: nil ].
+				callback: logEntryLabelCallback userdata: nil ].
 
 		"Add submenu with checkboxes"
 		submenu :=
@@ -498,10 +513,11 @@ SDL3Demo class >> example08TrayMenu [
 					label: 'Checkbox ', each
 					flags: SDL3TrayEntryFlags checkbox)
 				assertNotNullReturn;
-				callback: callback userdata: nil ].
+				callback: logEntryLabelCallback userdata: nil ].
 
-		logs add: 'Click on this window to enable/disable the system tray (with Pharo icon).'.
+		logs add: 'Click on the system tray menu with Pharo icon.'.
 		] value.
+
 
 	"main loop"
 	[ quit ] whileFalse: [

--- a/src/SDL3-Tests/SDL3Demo.class.st
+++ b/src/SDL3-Tests/SDL3Demo.class.st
@@ -434,6 +434,90 @@ SDL3Demo class >> example07SystemCursors [
 	Smalltalk snapshot: false andQuit: true
 ]
 
+{ #category : 'examples' }
+SDL3Demo class >> example08TrayMenu [
+	"SDL2 event subsystem conflicts with SDL3 event subsystem. Run this demo on a headless Pharo to appreciate it correctly.'.
+	Example:
+		./pharo Pharo.image eval --no-quit 'SDL3Demo example08TrayMenu' "
+
+	| demo quit logs sdl tray callback strings |
+	self
+		assert: (SDL2 wasInit: 16384) = 0 "SDL_INIT_EVENTS"
+		description: 'SDL2 is already initialized'.
+
+	demo := self new.
+	demo ensureInitSDL3; open.
+	sdl := LibSDL3 uniqueInstance.
+
+	quit := false.
+	logs := LinkedList new.
+	logs add: 'Click on this window to enable/disable the system tray (with Pharo icon).'.
+
+	strings := #('One' 'Two' 'Three' 'Four' 'Five').
+	callback :=
+		FFICallback
+			signature: #(void (void *userdata, SDL3TrayEntry *entryHandle)) "SDL3TrayEntry"
+			block: [ :userdata :entryHandle |
+				| entry |
+				entry := SDL3TrayEntry fromHandle: entryHandle.
+				logs add: 'Clicked on ', entry label.
+				entry remove ].
+
+	"main loop"
+	[ quit ] whileFalse: [
+
+		"Process all pending events"
+		demo pollEventsDo: [ :evt |
+			evt type = SDL3EventType quit
+				ifTrue: [ quit := true ].
+			evt type = SDL3EventType windowCloseRequested
+				ifTrue: [ quit := true ].
+			evt type = SDL3EventType mouseButtonDown
+				ifTrue: [
+					tray
+						ifNil: [
+							| iconSurface menu entry |
+							iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
+							tray := sdl newTrayIcon: iconSurface tooltip: 'PharoSDL3'.
+
+							menu := tray newMenu.
+							strings do: [ :each |
+								entry :=
+									menu
+										insertTrayEntryAtPos: -1
+										label: each
+										flags: SDL3TrayEntryFlags button.
+								entry assertNotNullReturn.
+								entry
+									callback: callback
+									userdata: nil.
+								iconSurface destroy ].
+							 ]
+						ifNotNil: [
+							"tray destroy.
+							tray := nil" ] ]
+			].
+		
+		"Render frame"
+		demo clearColor: Color blue muchDarker.
+		[ logs size > 50 ] whileTrue: [ logs removeFirst ]. "cap"
+		logs withIndexDo: [ :each :index |
+			demo
+				showText: each
+				x: 10 y: 10 * index
+				color: Color white ].
+		demo present.
+
+		"Do a little wait before next frame"
+		15 milliSeconds wait ].
+
+	"Tear down"
+	tray ifNotNil: [ tray destroy ].
+	demo close.
+	demo ensureQuitSDL3.
+	Smalltalk snapshot: false andQuit: true
+]
+
 { #category : 'renderer' }
 SDL3Demo >> clear [
 

--- a/src/SDL3-Tests/SDL3TrayTest.class.st
+++ b/src/SDL3-Tests/SDL3TrayTest.class.st
@@ -1,0 +1,126 @@
+Class {
+	#name : 'SDL3TrayTest',
+	#superclass : 'SDL3Test',
+	#instVars : [
+		'iconSurface',
+		'tray'
+	],
+	#category : 'SDL3-Tests-Library',
+	#package : 'SDL3-Tests',
+	#tag : 'Library'
+}
+
+{ #category : 'running' }
+SDL3TrayTest >> setUp [
+
+	super setUp.
+
+	"Ensure video subsystem is initialized"
+	self assert: (sdl initSubSystem: SDL3InitFlags video).
+	
+	iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
+	tray := sdl newTrayIcon: iconSurface tooltip: 'Test tooltip'
+]
+
+{ #category : 'running' }
+SDL3TrayTest >> tearDown [
+
+	iconSurface destroy.
+	tray destroy.
+	
+	super tearDown
+]
+
+{ #category : 'tests' }
+SDL3TrayTest >> test01EmptyMenu [
+
+	| menu |
+	menu := tray newMenu.
+
+	self assert: menu entries isEmpty
+]
+
+{ #category : 'tests' }
+SDL3TrayTest >> test02InsertButton [
+
+	| menu |
+	menu := tray newMenu.
+
+	(menu
+		insertEntryAt: 0
+		label: 'First entry'
+		flags: SDL3TrayEntryFlags button)
+		assertNotNullReturn.
+
+	self assert: menu entries size equals: 1.
+	self assert: menu entries first label equals: 'First entry'
+]
+
+{ #category : 'tests' }
+SDL3TrayTest >> test03AppendButton [
+
+	| menu |
+	menu := tray newMenu.
+
+	(menu
+		insertEntryAt: -1
+		label: 'First entry'
+		flags: SDL3TrayEntryFlags button)
+		assertNotNullReturn.
+
+	self assert: menu entries size equals: 1.
+	self assert: menu entries first label equals: 'First entry'
+]
+
+{ #category : 'tests' }
+SDL3TrayTest >> test04WrongInsertButton [
+
+	| menu |
+	menu := tray newMenu.
+
+	self
+		should: [
+			(menu
+				insertEntryAt: 7
+				label: 'Entry At Wrong Position'
+				flags: SDL3TrayEntryFlags button)
+				assertNotNullReturn ]
+		raise: SDL3Error.
+
+	self assert: menu entries isEmpty
+]
+
+{ #category : 'tests' }
+SDL3TrayTest >> test08ClickCallbacks [
+
+	| menu clicks menuEntries callback |
+	menu := tray newMenu.
+
+	clicks := OrderedCollection new.
+	callback :=
+		FFICallback
+			signature: #(void (void *userdata, SDL3TrayEntry *entryHolder))
+			block: [ :userdata :entryHolder |
+				clicks add: (SDL3TrayEntry fromHandle: entryHolder) ].
+	
+	menuEntries := (1 to: 10) collect: [ :each |
+		| menuEntry |
+		menuEntry :=
+			menu
+				insertEntryAt: each - 1
+				label: 'Entry', each asString
+				flags: SDL3TrayEntryFlags button.
+		menuEntry assertNotNullReturn.
+		menuEntry callback: callback userdata: nil.
+		menuEntry ].
+
+	menuEntries do: #click. "Simulate clicks"
+	
+	self assert: clicks size equals: menuEntries size.
+	self assert: clicks first label equals: 'Entry1'.
+	self assert: clicks last label equals: 'Entry10'.
+
+		
+	menuEntries with: clicks do: [ :eachMenuEntry :eachClick |
+		self assert: eachMenuEntry getHandle equals: eachClick getHandle ]
+]

--- a/src/SDL3-Tests/SDL3TrayTest.class.st
+++ b/src/SDL3-Tests/SDL3TrayTest.class.st
@@ -37,7 +37,9 @@ SDL3TrayTest >> test01EmptyMenu [
 	| menu |
 	menu := tray newMenu.
 
-	self assert: menu entries isEmpty
+	self assert: menu entries isEmpty.
+	
+	self assert: menu parentTray getHandle equals: tray getHandle
 ]
 
 { #category : 'tests' }
@@ -46,6 +48,7 @@ SDL3TrayTest >> test02InsertButton [
 	| menu |
 	menu := tray newMenu.
 
+	"Insert a button at position 0 (the only available position to insert)"
 	(menu
 		insertEntryAt: 0
 		label: 'First entry'
@@ -123,4 +126,56 @@ SDL3TrayTest >> test08ClickCallbacks [
 		
 	menuEntries with: clicks do: [ :eachMenuEntry :eachClick |
 		self assert: eachMenuEntry getHandle equals: eachClick getHandle ]
+]
+
+{ #category : 'tests' }
+SDL3TrayTest >> test09Checkbox [
+
+	| menu entry |
+	menu := tray newMenu.
+
+	entry :=
+		menu
+			insertEntryAt: -1
+			label: 'Checkbox'
+			flags: SDL3TrayEntryFlags checkbox.
+	entry assertNotNullReturn.
+
+	self deny: entry checked.
+
+	entry click.
+
+	self assert: entry checked
+]
+
+{ #category : 'tests' }
+SDL3TrayTest >> test10Submenu [
+
+	| menu submenuA submenuB |
+	menu := tray newMenu.
+
+	submenuA :=
+		(menu
+			insertEntryAt: -1
+			label: 'Submenu A'
+			flags: SDL3TrayEntryFlags submenu)
+			assertNotNullReturn;
+			newSubmenu.
+
+	self assert: submenuA entries isEmpty.
+	self assert: menu entries size equals: 1.
+	self assert: submenuA parentEntry equals: menu entries first.
+	self assert: submenuA parentTray isNull.
+
+	submenuB :=
+		(submenuA
+			insertEntryAt: -1
+			label: 'Submenu B'
+			flags: SDL3TrayEntryFlags submenu)
+			assertNotNullReturn;
+			newSubmenu.
+
+	self assert: submenuA entries size equals: 1.
+	self assert: submenuB parentEntry equals: submenuA entries first.
+	self assert: submenuB parentTray isNull
 ]

--- a/src/SDL3-Tests/SDL3TrayTest.class.st
+++ b/src/SDL3-Tests/SDL3TrayTest.class.st
@@ -39,7 +39,7 @@ SDL3TrayTest >> test01EmptyMenu [
 
 	self assert: menu entries isEmpty.
 	
-	self assert: menu parentTray getHandle equals: tray getHandle
+	self assert: menu parentTray equals: tray
 ]
 
 { #category : 'tests' }
@@ -125,7 +125,7 @@ SDL3TrayTest >> test08ClickCallbacks [
 
 		
 	menuEntries with: clicks do: [ :eachMenuEntry :eachClick |
-		self assert: eachMenuEntry getHandle equals: eachClick getHandle ]
+		self assert: eachMenuEntry equals: eachClick ]
 ]
 
 { #category : 'tests' }

--- a/src/SDL3-Tests/SDL3VideoTest.class.st
+++ b/src/SDL3-Tests/SDL3VideoTest.class.st
@@ -47,7 +47,7 @@ SDL3VideoTest >> test02CursorAPI [
 	cursor := sdl newSystemCursor: cursorId.
 	self assert: (sdl setCursor: cursor).
 
-	self assert: sdl getCursor getHandle equals: cursor getHandle.
+	self assert: sdl getCursor equals: cursor.
 
 	sdl hideCursor.
 	self deny: sdl cursorVisible.

--- a/src/SDL3-Tests/SDL3WindowTest.class.st
+++ b/src/SDL3-Tests/SDL3WindowTest.class.st
@@ -236,51 +236,6 @@ SDL3WindowTest >> test06Fullscreen [
 	window destroy
 ]
 
-{ #category : 'tests' }
-SDL3WindowTest >> test07TrayIcons [
-	"Note: even if this test creates a window, the API of tray icons doesn't require a window."
-
-	| window iconSurface tray menu clicks menuEntries |
-	window := sdl newWindowTitle: #test07TrayIcons w: 300 h: 200 flags: 0.
-	window assertNotNullReturn.
-
-	iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
-	tray := sdl newTrayIcon: iconSurface tooltip: #test07TrayIcons.
-	iconSurface destroy.
-
-	clicks := OrderedCollection new.
-
-	menu := tray newMenu.
-	menuEntries := (1 to: 10) collect: [ :each |
-		| menuEntry |
-		menuEntry :=
-			menu
-				insertTrayEntryAtPos: -1
-				label: 'Entry', each asString
-				flags: SDL3TrayEntryFlags button.
-		menuEntry
-			callback: (FFICallback
-				signature: #(void (void *userdata, SDL3TrayEntry *entryHolder))
-				block: [ :userdata :entryHolder |
-					clicks add: (SDL3TrayEntry fromHandle: entryHolder) ])
-			userdata: nil.
-		menuEntry ].
-
-	menuEntries do: #click. "Simulate clicks"
-	
-	self waitToSee.
-
-	self assert: clicks size equals: menuEntries size.
-	self assert: clicks first label equals: 'Entry1'.
-	self assert: clicks last label equals: 'Entry10'.
-	
-	menuEntries with: clicks do: [ :eachMenuEntry :eachClick |
-		self assert: eachMenuEntry getHandle equals: eachClick getHandle ].
-
-	tray destroy.
-	window destroy
-]
-
 { #category : 'private' }
 SDL3WindowTest >> waitToSee [
 	"Perform a wait to consume events and let user visually check the window"

--- a/src/SDL3-Tests/SDL3WindowTest.class.st
+++ b/src/SDL3-Tests/SDL3WindowTest.class.st
@@ -233,37 +233,29 @@ SDL3WindowTest >> test06Fullscreen [
 SDL3WindowTest >> test07TrayIcons [
 	"Note: even if this test creates a window, the API of tray icons doesn't require a window."
 
-	| window iconSurface tray trayMenu |
-	self timeLimit: self class waitDuration * 4.
-	
-	window := sdl newWindowTitle: #test07TrayIcons w: 800 h: 600 flags: 0.
+	| window iconSurface tray trayMenu clicks aSDL3TrayEntry |
+	window := sdl newWindowTitle: #test07TrayIcons w: 300 h: 200 flags: 0.
 	window assertNotNullReturn.
 
-"	iconExtent := 32 asPoint.
-	iconForm := Form extent: iconExtent depth: 32.
-	iconForm getCanvas
-		fillColor: Color transparent;
-		fillOval: (0@0 corner: iconExtent) color: Color blue."
 	iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
 
 	tray := sdl newTrayIcon: iconSurface tooltip: #test07TrayIcons.
 	iconSurface destroy.
 
+	clicks := OrderedCollection new.
+
 	trayMenu := tray newMenu.
-	trayMenu insertTrayEntryAtPos: -1 label: 'First' flags: SDL3TrayEntryFlags button.
-
-	self waitToSee.
-
-	iconSurface := (self iconNamed: #add) asUnownedNewSDL3Surface.
-	tray icon: iconSurface.
-	iconSurface destroy.
+	aSDL3TrayEntry := trayMenu insertTrayEntryAtPos: -1 label: 'First' flags: SDL3TrayEntryFlags button.
+	aSDL3TrayEntry
+		callback: (FFICallback
+			signature: #(void (void *userdata, SDL3TrayEntry *entry))
+			block: [ :userdata :entry |
+				clicks add: userdata -> entry ])
+		 userdata: nil.
 
 	self waitToSee.
 
 	tray destroy.
-
-	self waitToSee.
-
 	window destroy
 ]
 

--- a/src/SDL3-Tests/SDL3WindowTest.class.st
+++ b/src/SDL3-Tests/SDL3WindowTest.class.st
@@ -10,6 +10,13 @@ Class {
 }
 
 { #category : 'accessing' }
+SDL3WindowTest class >> defaultTimeLimit [
+	"Answe rthe default time limit, which includes the #waitDuration."
+
+	^ super defaultTimeLimit + self waitDuration
+]
+
+{ #category : 'accessing' }
 SDL3WindowTest class >> waitDuration [
 
 	^ waitDuration ifNil: [ 1 seconds ]
@@ -233,27 +240,42 @@ SDL3WindowTest >> test06Fullscreen [
 SDL3WindowTest >> test07TrayIcons [
 	"Note: even if this test creates a window, the API of tray icons doesn't require a window."
 
-	| window iconSurface tray trayMenu clicks aSDL3TrayEntry |
+	| window iconSurface tray menu clicks menuEntries |
 	window := sdl newWindowTitle: #test07TrayIcons w: 300 h: 200 flags: 0.
 	window assertNotNullReturn.
 
 	iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
-
 	tray := sdl newTrayIcon: iconSurface tooltip: #test07TrayIcons.
 	iconSurface destroy.
 
 	clicks := OrderedCollection new.
 
-	trayMenu := tray newMenu.
-	aSDL3TrayEntry := trayMenu insertTrayEntryAtPos: -1 label: 'First' flags: SDL3TrayEntryFlags button.
-	aSDL3TrayEntry
-		callback: (FFICallback
-			signature: #(void (void *userdata, SDL3TrayEntry *entry))
-			block: [ :userdata :entry |
-				clicks add: userdata -> entry ])
-		 userdata: nil.
+	menu := tray newMenu.
+	menuEntries := (1 to: 10) collect: [ :each |
+		| menuEntry |
+		menuEntry :=
+			menu
+				insertTrayEntryAtPos: -1
+				label: 'Entry', each asString
+				flags: SDL3TrayEntryFlags button.
+		menuEntry
+			callback: (FFICallback
+				signature: #(void (void *userdata, SDL3TrayEntry *entryHolder))
+				block: [ :userdata :entryHolder |
+					clicks add: (SDL3TrayEntry fromHandle: entryHolder) ])
+			userdata: nil.
+		menuEntry ].
 
+	menuEntries do: #click. "Simulate clicks"
+	
 	self waitToSee.
+
+	self assert: clicks size equals: menuEntries size.
+	self assert: clicks first label equals: 'Entry1'.
+	self assert: clicks last label equals: 'Entry10'.
+	
+	menuEntries with: clicks do: [ :eachMenuEntry :eachClick |
+		self assert: eachMenuEntry getHandle equals: eachClick getHandle ].
 
 	tray destroy.
 	window destroy

--- a/src/SDL3-Tests/SDL3WindowTest.class.st
+++ b/src/SDL3-Tests/SDL3WindowTest.class.st
@@ -229,6 +229,44 @@ SDL3WindowTest >> test06Fullscreen [
 	window destroy
 ]
 
+{ #category : 'tests' }
+SDL3WindowTest >> test07TrayIcons [
+	"Note: even if this test creates a window, the API of tray icons doesn't require a window."
+
+	| window iconSurface tray trayMenu |
+	self timeLimit: self class waitDuration * 4.
+	
+	window := sdl newWindowTitle: #test07TrayIcons w: 800 h: 600 flags: 0.
+	window assertNotNullReturn.
+
+"	iconExtent := 32 asPoint.
+	iconForm := Form extent: iconExtent depth: 32.
+	iconForm getCanvas
+		fillColor: Color transparent;
+		fillOval: (0@0 corner: iconExtent) color: Color blue."
+	iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
+
+	tray := sdl newTrayIcon: iconSurface tooltip: #test07TrayIcons.
+	iconSurface destroy.
+
+	trayMenu := tray newMenu.
+	trayMenu insertTrayEntryAtPos: -1 label: 'First' flags: SDL3TrayEntryFlags button.
+
+	self waitToSee.
+
+	iconSurface := (self iconNamed: #add) asUnownedNewSDL3Surface.
+	tray icon: iconSurface.
+	iconSurface destroy.
+
+	self waitToSee.
+
+	tray destroy.
+
+	self waitToSee.
+
+	window destroy
+]
+
 { #category : 'private' }
 SDL3WindowTest >> waitToSee [
 	"Perform a wait to consume events and let user visually check the window"


### PR DESCRIPTION
- Added a test that adds a button, but setting  callback is still missing.
- Added "forwarding API" in a couple of classes (push to pharo cig, SDL3 branch)
- Added flags, and renamed them similarly to other flags in the past, with a script:
```
	enumClass := SDL3TrayEntryFlags.
	renames := enumClass enumDeclToCamelCaseDictionary.

	"Apply rename refactorings"
	env := RBPackageEnvironment packageNames: #('SDL3-Own').
	env := env & (RBSelectorEnvironment new addMethod: (enumClass classSide >> #enumDecl); yourself) not.
	model := RBNamespace onEnvironment: env.

	allChanges := OrderedCollection new.
	renames keysAndValuesDo: [ :oldName :newName |
		allChanges addAll: (ReRenameMethodRefactoring new
	        model: model;
	        renameMethod: oldName
	        	in: enumClass classSide
				to: newName
				permutation: #();
	        renameChanges) changes ].

	allChanges := allChanges reject: [ :e |
		e class = RBAddMethodChange and: [
			"e protocol ~= #'accessing enum'"
			(e selector beginsWith: 'enumDecl') and: [ 
				e changeClassName = enumClass name ] ] ].

	allChanges do: #generateChanges.
```