### PR TITLE
Reify demo and loop + rename in SDL3EventMap

### DIFF
--- a/src/SDL3-Demos/SDL3App.class.st
+++ b/src/SDL3-Demos/SDL3App.class.st
@@ -1,0 +1,64 @@
+Class {
+	#name : 'SDL3App',
+	#superclass : 'Object',
+	#instVars : [
+		'sdl',
+		'loop'
+	],
+	#category : 'SDL3-Demos',
+	#package : 'SDL3-Demos'
+}
+
+{ #category : 'hooks' }
+SDL3App >> handleEvent: aSDL3MappedEvent [
+]
+
+{ #category : 'lifecycle' }
+SDL3App >> loopStopped [
+	"Prepare to close after terminating the main loop"
+]
+
+{ #category : 'lifecycle' }
+SDL3App >> loopWillStart [
+	"Prepare the demo before starting the main loop"
+]
+
+{ #category : 'hooks' }
+SDL3App >> newLoop [
+
+	^ SDL3MainLoop new
+]
+
+{ #category : 'lifecycle' }
+SDL3App >> start [
+
+	sdl := LibSDL3 uniqueInstance.
+
+	self assert: (sdl initSubSystem: self subsystemInitFlags).
+
+	self loopWillStart.
+
+	loop := self newLoop.
+	loop start
+]
+
+{ #category : 'hooks' }
+SDL3App >> stepBySeconds: aDelta [
+
+]
+
+{ #category : 'lifecycle' }
+SDL3App >> stop [
+
+	loop stop.
+
+	self loopStopped.
+
+	sdl quit
+]
+
+{ #category : 'hooks' }
+SDL3App >> subsystemInitFlags [
+
+	^ SDL3InitFlags video
+]

--- a/src/SDL3-Demos/SDL3MainLoop.class.st
+++ b/src/SDL3-Demos/SDL3MainLoop.class.st
@@ -1,0 +1,125 @@
+"
+I represent a particular SDL3 main loop that works with an ""app"" object.
+
+- regularly poll available events, map them to `SDL3MappedEvent`s and sends them to the app using `#handleEvent:` selector
+- send `#stepBySeconds:` to the app after polling all events
+- caps the step rate via Pharo wait
+
+"
+Class {
+	#name : 'SDL3MainLoop',
+	#superclass : 'Object',
+	#instVars : [
+		'process',
+		'event',
+		'session',
+		'delay',
+		'eventMap',
+		'periodMS',
+		'app',
+		'lastUS',
+		'lastStepUS'
+	],
+	#category : 'SDL3-Demos',
+	#package : 'SDL3-Demos'
+}
+
+{ #category : 'accessing' }
+SDL3MainLoop >> app [
+
+	^ app
+]
+
+{ #category : 'accessing' }
+SDL3MainLoop >> app: anObject [
+
+	app := anObject
+]
+
+{ #category : 'accessing' }
+SDL3MainLoop >> hertz: aNumber [
+
+	periodMS := 1000.0 / aNumber
+]
+
+{ #category : 'initialization' }
+SDL3MainLoop >> initialize [
+
+	super initialize.
+	
+	self hertz: 60.
+
+	delay := Delay forMilliseconds: 0.
+	eventMap := SDL3EventMap new.
+	event := SDL3Event new
+]
+
+{ #category : 'testing' }
+SDL3MainLoop >> isRunning [
+
+	^ process notNil and: [ process isTerminated not ]
+]
+
+{ #category : 'accessing' }
+SDL3MainLoop >> period: aDuration [
+
+	periodMS := aDuration asMilliSeconds asFloat
+]
+
+{ #category : 'running' }
+SDL3MainLoop >> start [
+
+	self isRunning ifTrue: [ ^ self ].
+
+	session := Smalltalk session.
+	lastUS := Time microsecondClockValue.
+	process := [ [ self step ] repeat ] forkAt: Processor lowIOPriority
+]
+
+{ #category : 'private' }
+SDL3MainLoop >> step [
+	"Perform an interation of the main loop."
+
+	self flag: #todo. "Session may change in midst of event handling as well"
+	Smalltalk session == session ifFalse: [ ^ self stop ].
+
+	[ LibSDL3 uniqueInstance pollEvent: event ]
+		whileTrue: [ app handleEvent: (eventMap value: event) ].
+
+	self stepApp.
+	self wait
+]
+
+{ #category : 'private' }
+SDL3MainLoop >> stepApp [
+
+	| currentUS |
+	currentUS := Time microsecondClockValue.
+	app stepBySeconds: (currentUS - lastStepUS) / 1e6.
+	lastStepUS := currentUS
+]
+
+{ #category : 'running' }
+SDL3MainLoop >> stop [
+
+	process ifNil: [ ^ self ].
+	process terminate.
+	process := nil.
+	session := nil.
+	lastUS := nil
+]
+
+{ #category : 'private' }
+SDL3MainLoop >> wait [
+	"May wait, according to the expected refresh rate"
+
+	| waitMS deltaUS currentUS |
+	currentUS := Time microsecondClockValue.
+	deltaUS := currentUS - lastUS.
+	lastUS := currentUS.
+
+	"Wait if spare time is at least 1ms.
+	(1 millisecond = 1000 microseconds)"
+	waitMS := (periodMS - deltaUS) // 1000.
+	waitMS > 0 ifTrue: [ delay setDelay: waitMS; wait ]
+]

--- a/src/SDL3-Demos/package.st
+++ b/src/SDL3-Demos/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'SDL3-Demos' }

--- a/src/SDL3-Own/SDL3EventMap.class.st
+++ b/src/SDL3-Own/SDL3EventMap.class.st
@@ -14,17 +14,6 @@ Class {
 }
 
 { #category : 'accessing' }
-SDL3EventMap >> conversionOf: aSDL3Event [
-	"Convert a `SDL3Event` as the corresponding `SDL3MappedEvent`."
-
-	| eventClass |
-	eventClass := self eventClassFor: aSDL3Event type.
-
-	"Inspired on FFIUnion's generated accessors (e.g. S3SDL_Event>>#display)"
-	^ eventClass fromHandle: (aSDL3Event getHandle referenceStructAt: 1 length: eventClass byteSize)
-]
-
-{ #category : 'accessing' }
 SDL3EventMap >> eventClassFor: typeNumber [
 
 	^ eventClassByTypeNumber at: typeNumber ifAbsent: [ SDL3CommonEvent ]
@@ -40,4 +29,18 @@ SDL3EventMap >> initialize [
 	SDL3MappedEvent allSubclassesDo: [ :eachEventClass |
 		eachEventClass eventTypes do: [ :eachEventType |
 			eventClassByTypeNumber at: eachEventType value put: eachEventClass ] ]
+]
+
+{ #category : 'accessing' }
+SDL3EventMap >> value: aSDL3Event [
+	"Answer a `SDL3MappedEvent` that corresponds to a `SDL3Event`."
+
+	| eventClass |
+	eventClass := self eventClassFor: aSDL3Event type.
+
+	"Inspired on FFIUnion's generated accessors (e.g. SDL3Event>>#display)"
+	^ eventClass fromHandle:
+		(aSDL3Event getHandle
+			referenceStructAt: 1
+			length: eventClass byteSize)
 ]

--- a/src/SDL3-Tests/SDL3Demo.class.st
+++ b/src/SDL3-Tests/SDL3Demo.class.st
@@ -790,7 +790,7 @@ SDL3Demo >> pollEvents [
 SDL3Demo >> pollEventsDo: aUnaryBlock [
 
 	[ sdl pollEvent: event ] whileTrue: [
-		aUnaryBlock value: (map conversionOf: event) ]
+		aUnaryBlock value: (map value: event) ]
 ]
 
 { #category : 'renderer' }


### PR DESCRIPTION
This adds a new package but it's not referenced from baseline yet.
Instead of waiting via Pharo scheduler, it should use either VSYNC or the new GPU low-level API (to avoid tearing).