### PR TITLE
Baseline: Remove UnifiedFFI as dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         id: sdl
         with:
           version: 3-latest
+          install-linux-dependencies: true
       - uses: actions/checkout@v4
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
       # Default value means that a failure in one combination cancels all 
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-13, Pharo64-14 ]
-        os: [ macos-latest, windows-latest ] #ubuntu-latest has some test failures
+        smalltalk: [ Pharo64-14 ]
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         smalltalk: [ Pharo64-14 ]
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        os: [ macos-latest, windows-latest ] # ubuntu-latest: video initialization fails
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:
@@ -22,7 +22,7 @@ jobs:
         id: sdl
         with:
           version: 3-latest
-          install-linux-dependencies: true
+          # install-linux-dependencies: true
       - uses: actions/checkout@v4
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SDL3 is a cross-platform development library designed to provide low-level acces
 
 ### 1. Load the Pharo project
 
-In a Pharo 12, 13, or 14 image, evaluate the following Metacello script:
+In a Pharo 14 image, evaluate the following Metacello script:
 
 ```smalltalk
 Metacello new
@@ -21,7 +21,7 @@ Metacello new
 
 Alternatively, from your terminal:
 ```bash
-curl https://get.pharo.org/130+vm | bash
+curl https://get.pharo.org/140+vm | bash
 ./pharo Pharo.image metacello install github://tinchodias/PharoSDL3:dev/src BaselineOfSDL3
 ```
 

--- a/src/BaselineOfSDL3/BaselineOfSDL3.class.st
+++ b/src/BaselineOfSDL3/BaselineOfSDL3.class.st
@@ -11,9 +11,7 @@ BaselineOfSDL3 >> baseline: spec [
 
 	spec
 		for: #common
-		do: [
-			spec baseline: 'UnifiedFFIFull' with: [ spec repository: 'github://tinchodias/UnifiedFFI:PackFloatToArity' ].
-
+		do: [ 
 			spec
 				postLoadDoIt: #postLoad;
 				package: 'SDL3';

--- a/src/SDL3-Tests/SDL3BasicTest.class.st
+++ b/src/SDL3-Tests/SDL3BasicTest.class.st
@@ -134,7 +134,9 @@ SDL3BasicTest >> test06Properties [
 SDL3BasicTest >> test07SubsystemLifecycle [
 	"Note: This test initializes and quits events subsystem independently if it was already initialized"
 
-	self assert: (sdl initSubSystem: SDL3InitFlags events).
+	self
+		assert: (sdl initSubSystem: SDL3InitFlags events)
+		description: 'Initialize event subsystem'.
 
 	self
 		assert: (sdl wasInit: SDL3InitFlags events)

--- a/src/SDL3-Tests/SDL3Demo.class.st
+++ b/src/SDL3-Tests/SDL3Demo.class.st
@@ -719,8 +719,9 @@ SDL3Demo >> ensureInitSDL3 [
 		appversion: 'v1.2.3'
 		appidentifier: 'org.pharo.sdl3.', self className.
 
-	"Initialize the video subsystem"
-	self assert: (sdl initSubSystem: SDL3InitFlags video)
+	self
+		assert: (sdl initSubSystem: SDL3InitFlags video)
+		description: 'Initialize video subsystem'
 ]
 
 { #category : 'lifecycle' }

--- a/src/SDL3-Tests/SDL3TrayTest.class.st
+++ b/src/SDL3-Tests/SDL3TrayTest.class.st
@@ -15,8 +15,9 @@ SDL3TrayTest >> setUp [
 
 	super setUp.
 
-	"Ensure video subsystem is initialized"
-	self assert: (sdl initSubSystem: SDL3InitFlags video).
+	self
+		assert: (sdl initSubSystem: SDL3InitFlags video)
+		description: 'Initialize video subsystem'.
 	
 	iconSurface := (self iconNamed: #pharo) asUnownedNewSDL3Surface.
 	tray := sdl newTrayIcon: iconSurface tooltip: 'Test tooltip'

--- a/src/SDL3-Tests/SDL3TrayTest.class.st
+++ b/src/SDL3-Tests/SDL3TrayTest.class.st
@@ -25,8 +25,8 @@ SDL3TrayTest >> setUp [
 { #category : 'running' }
 SDL3TrayTest >> tearDown [
 
-	iconSurface destroy.
-	tray destroy.
+	iconSurface ifNotNil: #destroy.
+	tray ifNotNil: #destroy.
 	
 	super tearDown
 ]

--- a/src/SDL3-Tests/SDL3VideoTest.class.st
+++ b/src/SDL3-Tests/SDL3VideoTest.class.st
@@ -11,8 +11,9 @@ SDL3VideoTest >> setUp [
 
 	super setUp.
 
-	"Ensure video subsystem is initialized"
-	self assert: (sdl initSubSystem: SDL3InitFlags video)
+	self
+		assert: (sdl initSubSystem: SDL3InitFlags video)
+		description: 'Initialize video subsystem'
 ]
 
 { #category : 'tests' }

--- a/src/SDL3-Tests/SDL3WindowTest.class.st
+++ b/src/SDL3-Tests/SDL3WindowTest.class.st
@@ -47,8 +47,9 @@ SDL3WindowTest >> setUp [
 
 	super setUp.
 
-	"Ensure video subsystem is initialized"
-	self assert: (sdl initSubSystem: SDL3InitFlags video)
+	self
+		assert: (sdl initSubSystem: SDL3InitFlags video)
+		description: 'Initialize video subsystem'
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
With this change, we narrow the CI to Pharo 14 and mac+win. 