### PR TITLE
Many refactorings

### DIFF
--- a/src/SDL3-API/SDL3GPUBuffer.extension.st
+++ b/src/SDL3-API/SDL3GPUBuffer.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'SDL3GPUBuffer' }
+
+{ #category : '*SDL3-API' }
+SDL3GPUBuffer >> releaseFromGPUDevice [
+
+	device ffiLibrary releaseGPUBufferDevice: device buffer: self
+]

--- a/src/SDL3-API/SDL3GPUCommandBuffer.extension.st
+++ b/src/SDL3-API/SDL3GPUCommandBuffer.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'SDL3GPUCommandBuffer' }
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> acquireGPUSwapchainTextureForWindow: window into: swapchainTexture width: swapchainTextureWidth height: swapchainTextureHeight [
+SDL3GPUCommandBuffer >> acquireSwapchainTextureForWindow: window into: swapchainTexture width: swapchainTextureWidth height: swapchainTextureHeight [
 
 	self ffiLibrary assertSuccess:
 		(self ffiLibrary
@@ -13,7 +13,7 @@ SDL3GPUCommandBuffer >> acquireGPUSwapchainTextureForWindow: window into: swapch
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> beginGPUComputePassStorageTextureBindings: storageTextureBindings numStorageTextureBindings: numStorageTextureBindings storageBufferBindings: storageBufferBindings numStorageBufferBindings: numStorageBufferBindings [
+SDL3GPUCommandBuffer >> beginComputePassTextures: storageTextureBindings count: numStorageTextureBindings storageBuffers: storageBufferBindings count: numStorageBufferBindings [
 
 	^ self ffiLibrary
 		  beginGPUComputePassCommandBuffer: self
@@ -24,13 +24,16 @@ SDL3GPUCommandBuffer >> beginGPUComputePassStorageTextureBindings: storageTextur
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> beginGPUCopyPass [
+SDL3GPUCommandBuffer >> beginCopyPass [
 
-	^ self ffiLibrary beginGPUCopyPass: self
+	^ (self ffiLibrary beginGPUCopyPass: self)
+		  assertNotNullReturn;
+		  device: self device;
+		  yourself
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> beginGPURenderPassColorTargetInfos: colorTargetInfos numColorTargets: numColorTargets depthStencilTargetInfo: depthStencilTargetInfo [
+SDL3GPUCommandBuffer >> beginRenderPassTargets: colorTargetInfos count: numColorTargets depthStencil: depthStencilTargetInfo [
 
 	^ self ffiLibrary
 		  beginGPURenderPassCommandBuffer: self
@@ -40,7 +43,7 @@ SDL3GPUCommandBuffer >> beginGPURenderPassColorTargetInfos: colorTargetInfos num
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> blitGPUTextureInfo: info [
+SDL3GPUCommandBuffer >> blit: info [
 
 	self ffiLibrary blitGPUTextureCommandBuffer: self info: info
 ]
@@ -53,7 +56,7 @@ SDL3GPUCommandBuffer >> cancel [
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> generateMipmapsForGPUTexture: texture [
+SDL3GPUCommandBuffer >> generateMipmaps: texture [
 
 	self ffiLibrary
 		generateMipmapsForGPUTextureCommandBuffer: self
@@ -61,19 +64,19 @@ SDL3GPUCommandBuffer >> generateMipmapsForGPUTexture: texture [
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> insertGPUDebugLabelText: text [
+SDL3GPUCommandBuffer >> insertDebugLabel: text [
 
 	self ffiLibrary insertGPUDebugLabelCommandBuffer: self text: text
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> popGPUDebugGroup [
+SDL3GPUCommandBuffer >> popDebugGroup [
 
 	self ffiLibrary popGPUDebugGroup: self
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> pushGPUComputeUniformDataSlotIndex: slotIndex data: data length: length [
+SDL3GPUCommandBuffer >> pushComputeUniformSlot: slotIndex data: data length: length [
 
 	self ffiLibrary
 		pushGPUComputeUniformDataCommandBuffer: self
@@ -83,13 +86,13 @@ SDL3GPUCommandBuffer >> pushGPUComputeUniformDataSlotIndex: slotIndex data: data
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> pushGPUDebugGroupName: name [
+SDL3GPUCommandBuffer >> pushDebugGroup: name [
 
 	self ffiLibrary pushGPUDebugGroupCommandBuffer: self name: name
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> pushGPUFragmentUniformDataSlotIndex: slotIndex data: data length: length [
+SDL3GPUCommandBuffer >> pushFragmentUniformSlot: slotIndex data: data length: length [
 
 	self ffiLibrary
 		pushGPUFragmentUniformDataCommandBuffer: self
@@ -99,13 +102,20 @@ SDL3GPUCommandBuffer >> pushGPUFragmentUniformDataSlotIndex: slotIndex data: dat
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> pushGPUVertexUniformDataSlotIndex: slotIndex data: data length: length [
+SDL3GPUCommandBuffer >> pushVertexUniformSlot: slotIndex data: data length: length [
 
 	self ffiLibrary
 		pushGPUVertexUniformDataCommandBuffer: self
 		slotIndex: slotIndex
 		data: data
 		length: length
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPUCommandBuffer >> releaseFromGPUDevice [
+	"Command buffers are released when they are submitted or canceled. Manual release is usually not needed but provided for completeness."
+
+	self cancel
 ]
 
 { #category : '*SDL3-API' }
@@ -120,11 +130,12 @@ SDL3GPUCommandBuffer >> submitAndAcquireFence [
 
 	^ (self ffiLibrary submitGPUCommandBufferAndAcquireFence: self)
 		  assertNotNullReturn;
+		  device: self device;
 		  yourself
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCommandBuffer >> waitAndAcquireGPUSwapchainTextureForWindow: window into: swapchainTexture width: swapchainTextureWidth height: swapchainTextureHeight [
+SDL3GPUCommandBuffer >> waitAndAcquireSwapchainTextureForWindow: window into: swapchainTexture width: swapchainTextureWidth height: swapchainTextureHeight [
 
 	self ffiLibrary assertSuccess:
 		(self ffiLibrary

--- a/src/SDL3-API/SDL3GPUComputePass.extension.st
+++ b/src/SDL3-API/SDL3GPUComputePass.extension.st
@@ -1,15 +1,7 @@
 Extension { #name : 'SDL3GPUComputePass' }
 
 { #category : '*SDL3-API' }
-SDL3GPUComputePass >> bindGPUComputePipeline: computePipeline [
-
-	self ffiLibrary
-		bindGPUComputePipelineComputePass: self
-		computePipeline: computePipeline
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUComputePass >> bindGPUComputeSamplersFirstSlot: firstSlot textureSamplerBindings: textureSamplerBindings numBindings: numBindings [
+SDL3GPUComputePass >> computeSamplersSlot: firstSlot bindings: textureSamplerBindings count: numBindings [
 
 	self ffiLibrary
 		bindGPUComputeSamplersComputePass: self
@@ -19,7 +11,7 @@ SDL3GPUComputePass >> bindGPUComputeSamplersFirstSlot: firstSlot textureSamplerB
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUComputePass >> bindGPUComputeStorageBuffersFirstSlot: firstSlot storageBuffers: storageBuffers numBindings: numBindings [
+SDL3GPUComputePass >> computeStorageBuffersSlot: firstSlot bindings: storageBuffers count: numBindings [
 
 	self ffiLibrary
 		bindGPUComputeStorageBuffersComputePass: self
@@ -29,7 +21,7 @@ SDL3GPUComputePass >> bindGPUComputeStorageBuffersFirstSlot: firstSlot storageBu
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUComputePass >> bindGPUComputeStorageTexturesFirstSlot: firstSlot storageTextures: storageTextures numBindings: numBindings [
+SDL3GPUComputePass >> computeStorageTexturesSlot: firstSlot bindings: storageTextures count: numBindings [
 
 	self ffiLibrary
 		bindGPUComputeStorageTexturesComputePass: self
@@ -39,7 +31,7 @@ SDL3GPUComputePass >> bindGPUComputeStorageTexturesFirstSlot: firstSlot storageT
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUComputePass >> dispatchGPUComputeIndirectBuffer: buffer offset: offset [
+SDL3GPUComputePass >> dispatchIndirectBuffer: buffer offset: offset [
 
 	self ffiLibrary
 		dispatchGPUComputeIndirectComputePass: self
@@ -48,7 +40,7 @@ SDL3GPUComputePass >> dispatchGPUComputeIndirectBuffer: buffer offset: offset [
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUComputePass >> dispatchWorkgroupCountX: groupcountX y: groupcountY z: groupcountZ [
+SDL3GPUComputePass >> dispatchX: groupcountX y: groupcountY z: groupcountZ [
 
 	self ffiLibrary
 		dispatchGPUComputeComputePass: self
@@ -61,4 +53,19 @@ SDL3GPUComputePass >> dispatchWorkgroupCountX: groupcountX y: groupcountY z: gro
 SDL3GPUComputePass >> end [
 
 	self ffiLibrary endGPUComputePass: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPUComputePass >> pipeline: computePipeline [
+
+	self ffiLibrary
+		bindGPUComputePipelineComputePass: self
+		computePipeline: computePipeline
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPUComputePass >> releaseFromGPUDevice [
+	"Passes are released when they are ended."
+
+	self end
 ]

--- a/src/SDL3-API/SDL3GPUComputePipeline.extension.st
+++ b/src/SDL3-API/SDL3GPUComputePipeline.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'SDL3GPUComputePipeline' }
+
+{ #category : '*SDL3-API' }
+SDL3GPUComputePipeline >> releaseFromGPUDevice [
+
+	device ffiLibrary
+		releaseGPUComputePipelineDevice: device
+		computePipeline: self
+]

--- a/src/SDL3-API/SDL3GPUCopyPass.extension.st
+++ b/src/SDL3-API/SDL3GPUCopyPass.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'SDL3GPUCopyPass' }
 
 { #category : '*SDL3-API' }
-SDL3GPUCopyPass >> copyGPUBufferToBufferSource: source destination: destination size: size cycle: cycle [
+SDL3GPUCopyPass >> copyBuffer: source destination: destination size: size cycle: cycle [
 
 	self ffiLibrary
 		copyGPUBufferToBufferCopyPass: self
@@ -12,7 +12,7 @@ SDL3GPUCopyPass >> copyGPUBufferToBufferSource: source destination: destination 
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCopyPass >> copyGPUTextureToTextureSource: source destination: destination w: w h: h d: d cycle: cycle [
+SDL3GPUCopyPass >> copyTexture: source destination: destination w: w h: h d: d cycle: cycle [
 
 	self ffiLibrary
 		copyGPUTextureToTextureCopyPass: self
@@ -25,13 +25,13 @@ SDL3GPUCopyPass >> copyGPUTextureToTextureSource: source destination: destinatio
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCopyPass >> downloadFromGPUBufferSource: source destination: destination [
+SDL3GPUCopyPass >> downloadBuffer: source destination: destination [
 
 	self ffiLibrary downloadFromGPUBufferCopyPass: self source: source destination: destination
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCopyPass >> downloadFromGPUTextureSource: source destination: destination [
+SDL3GPUCopyPass >> downloadTexture: source destination: destination [
 
 	self ffiLibrary downloadFromGPUTextureCopyPass: self source: source destination: destination
 ]
@@ -43,7 +43,14 @@ SDL3GPUCopyPass >> end [
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCopyPass >> uploadToGPUBufferSource: source destination: destination cycle: cycle [
+SDL3GPUCopyPass >> releaseFromGPUDevice [
+	"Passes are released when they are ended."
+
+	self end
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPUCopyPass >> uploadBuffer: source destination: destination cycle: cycle [
 
 	self ffiLibrary
 		uploadToGPUBufferCopyPass: self
@@ -53,7 +60,7 @@ SDL3GPUCopyPass >> uploadToGPUBufferSource: source destination: destination cycl
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUCopyPass >> uploadToGPUTextureSource: source destination: destination cycle: cycle [
+SDL3GPUCopyPass >> uploadTexture: source destination: destination cycle: cycle [
 
 	self ffiLibrary
 		uploadToGPUTextureCopyPass: self

--- a/src/SDL3-API/SDL3GPUDevice.extension.st
+++ b/src/SDL3-API/SDL3GPUDevice.extension.st
@@ -5,6 +5,7 @@ SDL3GPUDevice >> acquireGPUCommandBuffer [
 
 	^ (self ffiLibrary acquireGPUCommandBuffer: self)
 		  assertNotNullReturn;
+		  device: self;
 		  yourself
 ]
 
@@ -102,71 +103,9 @@ SDL3GPUDevice >> mapGPUTransferBuffer: transferBuffer cycle: cycle [
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPUDevice >> newGPUBufferCreateinfo: createinfo [
-
-	^ (self ffiLibrary newGPUBufferDevice: self createinfo: createinfo)
-		  assertNotNullReturn;
-		  yourself
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> newGPUComputePipelineCreateinfo: createinfo [
-
-	^ (self ffiLibrary
-		   newGPUComputePipelineDevice: self
-		   createinfo: createinfo)
-		  assertNotNullReturn;
-		  yourself
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> newGPUGraphicsPipelineCreateinfo: createinfo [
-
-	^ (self ffiLibrary
-		   newGPUGraphicsPipelineDevice: self
-		   createinfo: createinfo)
-		  assertNotNullReturn;
-		  yourself
-]
-
-{ #category : '*SDL3-API' }
 SDL3GPUDevice >> newGPURendererWindow: window [
 
 	^ (self ffiLibrary newGPURendererDevice: self window: window)
-		  assertNotNullReturn;
-		  yourself
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> newGPUSamplerCreateinfo: createinfo [
-
-	^ (self ffiLibrary newGPUSamplerDevice: self createinfo: createinfo)
-		  assertNotNullReturn;
-		  yourself
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> newGPUShaderCreateinfo: createinfo [
-
-	^ (self ffiLibrary newGPUShaderDevice: self createinfo: createinfo)
-		  assertNotNullReturn;
-		  yourself
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> newGPUTextureCreateinfo: createinfo [
-
-	^ (self ffiLibrary newGPUTextureDevice: self createinfo: createinfo)
-		  assertNotNullReturn;
-		  yourself
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> newGPUTransferBufferCreateinfo: createinfo [
-
-	^ (self ffiLibrary
-		   newGPUTransferBufferDevice: self
-		   createinfo: createinfo)
 		  assertNotNullReturn;
 		  yourself
 ]
@@ -181,60 +120,6 @@ SDL3GPUDevice >> propertiesID [
 SDL3GPUDevice >> queryGPUFence: fence [
 
 	^ self ffiLibrary queryGPUFenceDevice: self fence: fence
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> releaseGPUBuffer: buffer [
-
-	self ffiLibrary releaseGPUBufferDevice: self buffer: buffer
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> releaseGPUComputePipeline: computePipeline [
-
-	self ffiLibrary
-		releaseGPUComputePipelineDevice: self
-		computePipeline: computePipeline
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> releaseGPUFence: fence [
-
-	self ffiLibrary releaseGPUFenceDevice: self fence: fence
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> releaseGPUGraphicsPipeline: graphicsPipeline [
-
-	self ffiLibrary
-		releaseGPUGraphicsPipelineDevice: self
-		graphicsPipeline: graphicsPipeline
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> releaseGPUSampler: sampler [
-
-	self ffiLibrary releaseGPUSamplerDevice: self sampler: sampler
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> releaseGPUShader: shader [
-
-	self ffiLibrary releaseGPUShaderDevice: self shader: shader
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> releaseGPUTexture: texture [
-
-	self ffiLibrary releaseGPUTextureDevice: self texture: texture
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPUDevice >> releaseGPUTransferBuffer: transferBuffer [
-
-	self ffiLibrary
-		releaseGPUTransferBufferDevice: self
-		transferBuffer: transferBuffer
 ]
 
 { #category : '*SDL3-API' }

--- a/src/SDL3-API/SDL3GPUFence.extension.st
+++ b/src/SDL3-API/SDL3GPUFence.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'SDL3GPUFence' }
+
+{ #category : '*SDL3-API' }
+SDL3GPUFence >> releaseFromGPUDevice [
+
+	device ffiLibrary releaseGPUFenceDevice: device fence: self
+]

--- a/src/SDL3-API/SDL3GPUGraphicsPipeline.extension.st
+++ b/src/SDL3-API/SDL3GPUGraphicsPipeline.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'SDL3GPUGraphicsPipeline' }
+
+{ #category : '*SDL3-API' }
+SDL3GPUGraphicsPipeline >> releaseFromGPUDevice [
+
+	device ffiLibrary
+		releaseGPUGraphicsPipelineDevice: device
+		graphicsPipeline: self
+]

--- a/src/SDL3-API/SDL3GPURenderPass.extension.st
+++ b/src/SDL3-API/SDL3GPURenderPass.extension.st
@@ -1,93 +1,6 @@
 Extension { #name : 'SDL3GPURenderPass' }
 
 { #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUFragmentSamplersFirstSlot: firstSlot textureSamplerBindings: textureSamplerBindings numBindings: numBindings [
-
-	self ffiLibrary
-		bindGPUFragmentSamplersRenderPass: self
-		firstSlot: firstSlot
-		textureSamplerBindings: textureSamplerBindings
-		numBindings: numBindings
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUFragmentStorageBuffersFirstSlot: firstSlot storageBuffers: storageBuffers numBindings: numBindings [
-
-	self ffiLibrary
-		bindGPUFragmentStorageBuffersRenderPass: self
-		firstSlot: firstSlot
-		storageBuffers: storageBuffers
-		numBindings: numBindings
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUFragmentStorageTexturesFirstSlot: firstSlot storageTextures: storageTextures numBindings: numBindings [
-
-	self ffiLibrary
-		bindGPUFragmentStorageTexturesRenderPass: self
-		firstSlot: firstSlot
-		storageTextures: storageTextures
-		numBindings: numBindings
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUGraphicsPipeline: graphicsPipeline [
-
-	self ffiLibrary
-		bindGPUGraphicsPipelineRenderPass: self
-		graphicsPipeline: graphicsPipeline
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUIndexBufferBinding: binding indexElementSize: indexElementSize [
-
-	self ffiLibrary
-		bindGPUIndexBufferRenderPass: self
-		binding: binding
-		indexElementSize: indexElementSize
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUVertexBuffersFirstSlot: firstSlot bindings: bindings numBindings: numBindings [
-
-	self ffiLibrary
-		bindGPUVertexBuffersRenderPass: self
-		firstSlot: firstSlot
-		bindings: bindings
-		numBindings: numBindings
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUVertexSamplersFirstSlot: firstSlot textureSamplerBindings: textureSamplerBindings numBindings: numBindings [
-
-	self ffiLibrary
-		bindGPUVertexSamplersRenderPass: self
-		firstSlot: firstSlot
-		textureSamplerBindings: textureSamplerBindings
-		numBindings: numBindings
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUVertexStorageBuffersFirstSlot: firstSlot storageBuffers: storageBuffers numBindings: numBindings [
-
-	self ffiLibrary
-		bindGPUVertexStorageBuffersRenderPass: self
-		firstSlot: firstSlot
-		storageBuffers: storageBuffers
-		numBindings: numBindings
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> bindGPUVertexStorageTexturesFirstSlot: firstSlot storageTextures: storageTextures numBindings: numBindings [
-
-	self ffiLibrary
-		bindGPUVertexStorageTexturesRenderPass: self
-		firstSlot: firstSlot
-		storageTextures: storageTextures
-		numBindings: numBindings
-]
-
-{ #category : '*SDL3-API' }
 SDL3GPURenderPass >> blendConstants: blendConstants [
 
 	self ffiLibrary
@@ -96,17 +9,7 @@ SDL3GPURenderPass >> blendConstants: blendConstants [
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPURenderPass >> drawGPUIndexedPrimitivesIndirectBuffer: buffer offset: offset drawCount: drawCount [
-
-	self ffiLibrary
-		drawGPUIndexedPrimitivesIndirectRenderPass: self
-		buffer: buffer
-		offset: offset
-		drawCount: drawCount
-]
-
-{ #category : '*SDL3-API' }
-SDL3GPURenderPass >> drawGPUIndexedPrimitivesNumIndices: numIndices numInstances: numInstances firstIndex: firstIndex vertexOffset: vertexOffset firstInstance: firstInstance [
+SDL3GPURenderPass >> drawIndexedPrimitives: numIndices instances: numInstances firstIndex: firstIndex vertexOffset: vertexOffset firstInstance: firstInstance [
 
 	self ffiLibrary
 		drawGPUIndexedPrimitivesRenderPass: self
@@ -118,17 +21,17 @@ SDL3GPURenderPass >> drawGPUIndexedPrimitivesNumIndices: numIndices numInstances
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPURenderPass >> drawGPUPrimitivesIndirectBuffer: buffer offset: offset drawCount: drawCount [
+SDL3GPURenderPass >> drawIndexedPrimitivesIndirectBuffer: buffer offset: offset drawCount: drawCount [
 
 	self ffiLibrary
-		drawGPUPrimitivesIndirectRenderPass: self
+		drawGPUIndexedPrimitivesIndirectRenderPass: self
 		buffer: buffer
 		offset: offset
 		drawCount: drawCount
 ]
 
 { #category : '*SDL3-API' }
-SDL3GPURenderPass >> drawGPUPrimitivesNumVertices: numVertices numInstances: numInstances firstVertex: firstVertex firstInstance: firstInstance [
+SDL3GPURenderPass >> drawPrimitives: numVertices instances: numInstances firstVertex: firstVertex firstInstance: firstInstance [
 
 	self ffiLibrary
 		drawGPUPrimitivesRenderPass: self
@@ -139,9 +42,73 @@ SDL3GPURenderPass >> drawGPUPrimitivesNumVertices: numVertices numInstances: num
 ]
 
 { #category : '*SDL3-API' }
+SDL3GPURenderPass >> drawPrimitivesIndirectBuffer: buffer offset: offset drawCount: drawCount [
+
+	self ffiLibrary
+		drawGPUPrimitivesIndirectRenderPass: self
+		buffer: buffer
+		offset: offset
+		drawCount: drawCount
+]
+
+{ #category : '*SDL3-API' }
 SDL3GPURenderPass >> end [
 
 	self ffiLibrary endGPURenderPass: self
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> fragmentSamplersSlot: firstSlot bindings: textureSamplerBindings count: numBindings [
+
+	self ffiLibrary
+		bindGPUFragmentSamplersRenderPass: self
+		firstSlot: firstSlot
+		textureSamplerBindings: textureSamplerBindings
+		numBindings: numBindings
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> fragmentStorageBuffersSlot: firstSlot bindings: storageBuffers count: numBindings [
+
+	self ffiLibrary
+		bindGPUFragmentStorageBuffersRenderPass: self
+		firstSlot: firstSlot
+		storageBuffers: storageBuffers
+		numBindings: numBindings
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> fragmentStorageTexturesSlot: firstSlot bindings: storageTextures count: numBindings [
+
+	self ffiLibrary
+		bindGPUFragmentStorageTexturesRenderPass: self
+		firstSlot: firstSlot
+		storageTextures: storageTextures
+		numBindings: numBindings
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> indexBuffer: binding elementSize: indexElementSize [
+
+	self ffiLibrary
+		bindGPUIndexBufferRenderPass: self
+		binding: binding
+		indexElementSize: indexElementSize
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> pipeline: graphicsPipeline [
+
+	self ffiLibrary
+		bindGPUGraphicsPipelineRenderPass: self
+		graphicsPipeline: graphicsPipeline
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> releaseFromGPUDevice [
+	"Passes are released when they are ended."
+
+	self end
 ]
 
 { #category : '*SDL3-API' }
@@ -156,6 +123,46 @@ SDL3GPURenderPass >> stencilReference: reference [
 	self ffiLibrary
 		setGPUStencilReferenceRenderPass: self
 		reference: reference
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> vertexBuffersSlot: firstSlot bindings: bindings count: numBindings [
+
+	self ffiLibrary
+		bindGPUVertexBuffersRenderPass: self
+		firstSlot: firstSlot
+		bindings: bindings
+		numBindings: numBindings
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> vertexSamplersSlot: firstSlot bindings: textureSamplerBindings count: numBindings [
+
+	self ffiLibrary
+		bindGPUVertexSamplersRenderPass: self
+		firstSlot: firstSlot
+		textureSamplerBindings: textureSamplerBindings
+		numBindings: numBindings
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> vertexStorageBuffersSlot: firstSlot bindings: storageBuffers count: numBindings [
+
+	self ffiLibrary
+		bindGPUVertexStorageBuffersRenderPass: self
+		firstSlot: firstSlot
+		storageBuffers: storageBuffers
+		numBindings: numBindings
+]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderPass >> vertexStorageTexturesSlot: firstSlot bindings: storageTextures count: numBindings [
+
+	self ffiLibrary
+		bindGPUVertexStorageTexturesRenderPass: self
+		firstSlot: firstSlot
+		storageTextures: storageTextures
+		numBindings: numBindings
 ]
 
 { #category : '*SDL3-API' }

--- a/src/SDL3-API/SDL3GPURenderState.extension.st
+++ b/src/SDL3-API/SDL3GPURenderState.extension.st
@@ -16,3 +16,10 @@ SDL3GPURenderState >> fragmentUniformsSlotIndex: slotIndex data: data length: le
 			data: data
 			length: length)
 ]
+
+{ #category : '*SDL3-API' }
+SDL3GPURenderState >> releaseFromGPUDevice [
+	"Render states are technically destroyed via the renderer's library handle, but we can treat them as device-owned for consistent API."
+
+	self destroy
+]

--- a/src/SDL3-API/SDL3GPUSampler.extension.st
+++ b/src/SDL3-API/SDL3GPUSampler.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'SDL3GPUSampler' }
+
+{ #category : '*SDL3-API' }
+SDL3GPUSampler >> releaseFromGPUDevice [
+
+	device ffiLibrary releaseGPUSamplerDevice: device sampler: self
+]

--- a/src/SDL3-API/SDL3GPUShader.extension.st
+++ b/src/SDL3-API/SDL3GPUShader.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'SDL3GPUShader' }
+
+{ #category : '*SDL3-API' }
+SDL3GPUShader >> releaseFromGPUDevice [
+
+	device ffiLibrary releaseGPUShaderDevice: device shader: self
+]

--- a/src/SDL3-API/SDL3GPUTexture.extension.st
+++ b/src/SDL3-API/SDL3GPUTexture.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'SDL3GPUTexture' }
+
+{ #category : '*SDL3-API' }
+SDL3GPUTexture >> releaseFromGPUDevice [
+
+	device ffiLibrary releaseGPUTextureDevice: device texture: self
+]

--- a/src/SDL3-API/SDL3GPUTransferBuffer.extension.st
+++ b/src/SDL3-API/SDL3GPUTransferBuffer.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'SDL3GPUTransferBuffer' }
+
+{ #category : '*SDL3-API' }
+SDL3GPUTransferBuffer >> releaseFromGPUDevice [
+
+	device ffiLibrary
+		releaseGPUTransferBufferDevice: device
+		transferBuffer: self
+]

--- a/src/SDL3-API/SDL3Renderer.extension.st
+++ b/src/SDL3-API/SDL3Renderer.extension.st
@@ -230,17 +230,7 @@ SDL3Renderer >> name [
 ]
 
 { #category : '*SDL3-API' }
-SDL3Renderer >> newGPURenderStateCreateinfo: createinfo [
-
-	^ (self ffiLibrary
-		   newGPURenderStateRenderer: self
-		   createinfo: createinfo)
-		  assertNotNullReturn;
-		  yourself
-]
-
-{ #category : '*SDL3-API' }
-SDL3Renderer >> newTextureFormat: format access: access w: w h: h [
+SDL3Renderer >> newTextureFormat: format access: access width: w height: h [
 
 	^ (self ffiLibrary
 		   newTextureRenderer: self

--- a/src/SDL3-Compute-Tests/SDL3ComputePipelineTest.class.st
+++ b/src/SDL3-Compute-Tests/SDL3ComputePipelineTest.class.st
@@ -47,7 +47,8 @@ SDL3ComputePipelineTest >> test01SimpleMath [
 	"Case 1: Simple Buffer Math
 	Reads from input buffer, multiplies by 2, writes to result buffer."
 
-	| inputData inputBuffer resultBuffer computePipeline commandBuffer computePass transferBuffer mappedAddress resultData numElements byteSize rwBindings roBindings |
+	| inputData inputBuffer resultBuffer computePipeline commandBuffer transferBuffer
+	resultData numElements byteSize rwBindings roBindings |
 	
 	numElements := 1024.
 	byteSize := numElements * FFIFloat32 externalTypeSize.
@@ -67,18 +68,17 @@ SDL3ComputePipelineTest >> test01SimpleMath [
 	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
 
 	"3. Upload input data"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: inputData to: mappedAddress size: byteSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: inputData to: mappedAddress size: byteSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
 	
 	"A. Upload copy"
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: inputBuffer; offset: 0; size: byteSize; yourself)
-		cycle: false;
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: inputBuffer; offset: 0; size: byteSize; yourself)
+			cycle: false ].
 
 	"B. Compute"
 	computePipeline := SDL3TestComputeMathShaderSource newComputePipelineAmong: shaderFormats device: gpuDevice.
@@ -90,44 +90,38 @@ SDL3ComputePipelineTest >> test01SimpleMath [
 	roBindings := FFIArray newType: ExternalAddress size: 1.
 	roBindings at: 1 put: inputBuffer getHandle.
 
-	computePass := commandBuffer
-		 beginGPUComputePassStorageTextureBindings: nil
-		 numStorageTextureBindings: 0
-		 storageBufferBindings: rwBindings
-		 numStorageBufferBindings: 1.
-		
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass bindGPUComputeStorageBuffersFirstSlot: 0 storageBuffers: roBindings numBindings: 1.
-	
-	computePass dispatchWorkgroupCountX: (SDL3TestComputeMathShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1.
-	computePass end.
+	commandBuffer computePassTextures: #() computeStorageBuffers: rwBindings do: [ :computePass |
+		computePass
+			pipeline: computePipeline;
+			computeStorageBuffers: roBindings slot: 0;
+			dispatchX: (SDL3TestComputeMathShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1 ].
 	
 	commandBuffer submit.
 
 	"4. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUBufferSource: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
-		destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadBuffer: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
+			destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself) ].
+	
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"5. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numElements.
-	1 to: numElements do: [ :i |
-		self assert: (resultData at: i) equals: (i * 2) asFloat ].
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numElements.
+		1 to: numElements do: [ :i |
+		self assert: (resultData at: i) equals: (i * 2) asFloat ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUComputePipeline: computePipeline.
-	gpuDevice releaseGPUBuffer: inputBuffer.
-	gpuDevice releaseGPUBuffer: resultBuffer.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	computePipeline release.
+	inputBuffer release.
+	resultBuffer release.
+	transferBuffer release.
 	inputData free
 ]
 
@@ -136,8 +130,9 @@ SDL3ComputePipelineTest >> test02Uniforms [
 	"Case 2: Uniform & Buffer Interaction
 	Reads multiplier and offset from uniform buffer, writes results to storage buffer."
 
-	| resultBuffer computePipeline commandBuffer computePass transferBuffer mappedAddress resultData uniforms numElements byteSize rwBindings |
-	
+	| resultBuffer computePipeline commandBuffer transferBuffer resultData uniforms
+	numElements byteSize rwBindings |
+
 	numElements := 1024.
 	byteSize := numElements * FFIFloat32 externalTypeSize.
 
@@ -157,48 +152,39 @@ SDL3ComputePipelineTest >> test02Uniforms [
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
 	commandBuffer
-		pushGPUComputeUniformDataSlotIndex: 0
-		data: uniforms
-		length: uniforms class structureSize.
+		pushComputeUniform: uniforms slot: 0.
 
 	rwBindings := FFIArray newType: SDL3GPUStorageBufferReadWriteBinding size: 1.
 	rwBindings first buffer: resultBuffer; cycle: false.
 
-	computePass := commandBuffer
-		 beginGPUComputePassStorageTextureBindings: nil
-		 numStorageTextureBindings: 0
-		 storageBufferBindings: rwBindings
-		 numStorageBufferBindings: 1.
-
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass dispatchWorkgroupCountX: (SDL3TestComputeUniformShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1.
-	computePass end.
+	commandBuffer computePassTextures: #() computeStorageBuffers: rwBindings do: [ :computePass |
+		computePass pipeline: computePipeline.
+		computePass dispatchX: (SDL3TestComputeUniformShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1 ].
 	
 	commandBuffer submit.
 	
 	"4. Download results"
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUBufferSource: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
-		destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadBuffer: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
+			destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"5. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numElements.
-	1 to: numElements do: [ :i |
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numElements.
+		1 to: numElements do: [ :i |
 		"Expected: (i-1) * 10.0 + 5.0"
-		self assert: (resultData at: i) equals: ((i - 1) * 10.0 + 5.0) asFloat ].
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+		self assert: (resultData at: i) equals: ((i - 1) * 10.0 + 5.0) asFloat ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUComputePipeline: computePipeline.
-	gpuDevice releaseGPUBuffer: resultBuffer.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	computePipeline release.
+	resultBuffer release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -206,33 +192,42 @@ SDL3ComputePipelineTest >> test03MultiDispatchChaining [
 	"Case 3: Multi-Dispatch Chaining & Barriers
 	Chains two dispatches: Dispatch A adds 1.0, Dispatch B adds another 1.0."
 
-	| bufferA bufferB bufferC computePipeline commandBuffer computePass transferBuffer mappedAddress resultData numElements inputData byteSize rwBindingsA roBindingsA rwBindingsB roBindingsB |
-	
+	| bufferA bufferB bufferC computePipeline commandBuffer transferBuffer resultData numElements inputData
+	byteSize rwBindingsA roBindingsA rwBindingsB roBindingsB |
+
 	numElements := 1024.
 	byteSize := numElements * FFIFloat32 externalTypeSize.
 
 	"1. Create 3 buffers for double-buffering style chain"
-	bufferA := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ size: byteSize.
-	bufferB := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ | SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE size: byteSize.
-	bufferC := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE size: byteSize.
-	
+	bufferA :=
+		gpuDevice
+			newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ
+			size: byteSize.
+	bufferB :=
+		gpuDevice
+			newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ | SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE
+			size: byteSize.
+	bufferC :=
+		gpuDevice
+			newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE
+			size: byteSize.
+
 	"Initial data: 10.0"
 	inputData := FFIArray newType: FFIFloat32 size: numElements.
 	1 to: numElements do: [ :i | inputData at: i put: 10.0 ].
 
 	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: inputData to: mappedAddress size: byteSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: inputData to: mappedAddress size: byteSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
 	
 	"A. Upload"
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: bufferA; offset: 0; size: byteSize; yourself)
-		cycle: false;
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: bufferA; offset: 0; size: byteSize; yourself)
+			cycle: false ].
 
 	"B. Setup pipeline"
 	computePipeline := SDL3TestComputeAddOneShaderSource
@@ -245,11 +240,10 @@ SDL3ComputePipelineTest >> test03MultiDispatchChaining [
 	roBindingsA := FFIArray newType: ExternalAddress size: 1.
 	roBindingsA at: 1 put: bufferA getHandle.
 
-	computePass := commandBuffer beginGPUComputePassStorageTextureBindings: nil numStorageTextureBindings: 0 storageBufferBindings: rwBindingsA numStorageBufferBindings: 1.
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass bindGPUComputeStorageBuffersFirstSlot: 0 storageBuffers: roBindingsA numBindings: 1.
-	computePass dispatchWorkgroupCountX: (SDL3TestComputeAddOneShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1.
-	computePass end.
+	commandBuffer computePassTextures: #() computeStorageBuffers: rwBindingsA do: [ :computePass |
+		computePass pipeline: computePipeline.
+		computePass computeStorageBuffers: roBindingsA slot: 0.
+		computePass dispatchX: (SDL3TestComputeAddOneShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1 ].
 	
 	"D. Dispatch B: B -> C"
 	rwBindingsB := FFIArray newType: SDL3GPUStorageBufferReadWriteBinding size: 1.
@@ -257,39 +251,37 @@ SDL3ComputePipelineTest >> test03MultiDispatchChaining [
 	roBindingsB := FFIArray newType: ExternalAddress size: 1.
 	roBindingsB at: 1 put: bufferB getHandle.
 
-	computePass := commandBuffer beginGPUComputePassStorageTextureBindings: nil numStorageTextureBindings: 0 storageBufferBindings: rwBindingsB numStorageBufferBindings: 1.
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass bindGPUComputeStorageBuffersFirstSlot: 0 storageBuffers: roBindingsB numBindings: 1.
-	computePass dispatchWorkgroupCountX: (SDL3TestComputeAddOneShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1.
-	computePass end.
+	commandBuffer computePassTextures: #() computeStorageBuffers: rwBindingsB do: [ :computePass |
+		computePass pipeline: computePipeline.
+		computePass computeStorageBuffers: roBindingsB slot: 0.
+		computePass dispatchX: (SDL3TestComputeAddOneShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1 ].
 	
 	commandBuffer submit.
 
 	"3. Download results from C"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUBufferSource: (SDL_GPUBufferRegion new buffer: bufferC; offset: 0; size: byteSize; yourself)
-		destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadBuffer: (SDL_GPUBufferRegion new buffer: bufferC; offset: 0; size: byteSize; yourself)
+			destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"4. Assert: 10.0 + 1.0 + 1.0 = 12.0"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numElements.
-	1 to: numElements do: [ :i |
-		self assert: (resultData at: i) equals: 12.0 ].
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numElements.
+		1 to: numElements do: [ :i |
+		self assert: (resultData at: i) equals: 12.0 ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUComputePipeline: computePipeline.
-	gpuDevice releaseGPUBuffer: bufferA.
-	gpuDevice releaseGPUBuffer: bufferB.
-	gpuDevice releaseGPUBuffer: bufferC.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	computePipeline release.
+	bufferA release.
+	bufferB release.
+	bufferC release.
+	transferBuffer release.
 	inputData free
 ]
 
@@ -298,8 +290,9 @@ SDL3ComputePipelineTest >> test04StructuredBuffers [
 	"Case 4: Structured Buffers & Alignment
 	Uses SDL3TestComputeStruct to show 16-byte alignment."
 
-	| inputData inputBuffer resultBuffer computePipeline commandBuffer computePass transferBuffer mappedAddress resultData numElements byteSize rwBindings roBindings |
-	
+	| inputData inputBuffer resultBuffer computePipeline commandBuffer transferBuffer resultData
+	numElements byteSize rwBindings roBindings |
+
 	numElements := 1024.
 	byteSize := numElements * SDL3TestComputeStruct structureSize.
 
@@ -318,18 +311,17 @@ SDL3ComputePipelineTest >> test04StructuredBuffers [
 	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
 
 	"3. Upload"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: inputData to: mappedAddress size: byteSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: inputData to: mappedAddress size: byteSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
 	
 	"A. Upload"
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: inputBuffer; offset: 0; size: byteSize; yourself)
-		cycle: false;
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: inputBuffer; offset: 0; size: byteSize; yourself)
+			cycle: false ].
 
 	"B. Compute"
 	computePipeline := SDL3TestComputeStructShaderSource
@@ -341,43 +333,41 @@ SDL3ComputePipelineTest >> test04StructuredBuffers [
 	roBindings := FFIArray newType: ExternalAddress size: 1.
 	roBindings at: 1 put: inputBuffer getHandle.
 
-	computePass := commandBuffer beginGPUComputePassStorageTextureBindings: nil numStorageTextureBindings: 0 storageBufferBindings: rwBindings numStorageBufferBindings: 1.
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass bindGPUComputeStorageBuffersFirstSlot: 0 storageBuffers: roBindings numBindings: 1.
-	computePass dispatchWorkgroupCountX: (SDL3TestComputeStructShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1.
-	computePass end.
+	commandBuffer computePassTextures: #() computeStorageBuffers: rwBindings do: [ :computePass |
+		computePass pipeline: computePipeline.
+		computePass computeStorageBuffers: roBindings slot: 0.
+		computePass dispatchX: (SDL3TestComputeStructShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1 ].
 	
 	commandBuffer submit.
 	
 	"4. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUBufferSource: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
-		destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadBuffer: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
+			destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"5. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: SDL3TestComputeStruct size: numElements.
-	1 to: numElements do: [ :i |
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: SDL3TestComputeStruct size: numElements.
+		1 to: numElements do: [ :i |
 		| s |
 		s := resultData at: i.
 		self assert: s x equals: 11.0.
 		self assert: s y equals: 22.0.
 		self assert: s z equals: 33.0.
-		self assert: s w equals: 44.0 ].
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+		self assert: s w equals: 44.0 ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUComputePipeline: computePipeline.
-	gpuDevice releaseGPUBuffer: inputBuffer.
-	gpuDevice releaseGPUBuffer: resultBuffer.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	computePipeline release.
+	inputBuffer release.
+	resultBuffer release.
+	transferBuffer release.
 	inputData free
 ]
 
@@ -386,8 +376,8 @@ SDL3ComputePipelineTest >> test05LargeBufferIndexing [
 	"Case 5: Large Buffer Indexing
 	Demonstrates global indexing math in a flat buffer."
 
-	| resultBuffer computePipeline commandBuffer computePass transferBuffer mappedAddress resultData numElements rwBindings byteSize |
-	
+	| resultBuffer computePipeline commandBuffer transferBuffer resultData numElements rwBindings byteSize |
+
 	numElements := 1024.
 	byteSize := numElements * FFIUInt32 externalTypeSize.
 
@@ -405,34 +395,32 @@ SDL3ComputePipelineTest >> test05LargeBufferIndexing [
 	rwBindings := FFIArray newType: SDL3GPUStorageBufferReadWriteBinding size: 1.
 	rwBindings first buffer: resultBuffer; cycle: false.
 
-	computePass := commandBuffer beginGPUComputePassStorageTextureBindings: nil numStorageTextureBindings: 0 storageBufferBindings: rwBindings numStorageBufferBindings: 1.
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass dispatchWorkgroupCountX: (SDL3TestComputeIndexShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1.
-	computePass end.
+	commandBuffer computePassTextures: #() computeStorageBuffers: rwBindings do: [ :computePass |
+		computePass pipeline: computePipeline.
+		computePass dispatchX: (SDL3TestComputeIndexShaderSource dispatchWorkgroupCountXFor: numElements) y: 1 z: 1 ].
 	commandBuffer submit.
 	
 	"3. Download results"
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUBufferSource: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
-		destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadBuffer: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
+			destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"4. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIUInt32 size: numElements.
-	1 to: numElements do: [ :i |
-		self assert: (resultData at: i) equals: i - 1 ].
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIUInt32 size: numElements.
+		1 to: numElements do: [ :i |
+		self assert: (resultData at: i) equals: i - 1 ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUComputePipeline: computePipeline.
-	gpuDevice releaseGPUBuffer: resultBuffer.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	computePipeline release.
+	resultBuffer release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -440,8 +428,9 @@ SDL3ComputePipelineTest >> test06StorageTextures [
 	"Case 6: Storage Textures
 	Writes colors to a ReadWrite texture from compute."
 
-	| resultTexture computePipeline commandBuffer computePass transferBuffer mappedAddress resultData texWidth texHeight byteSize rwBindings |
-	
+	| resultTexture computePipeline commandBuffer transferBuffer resultData texWidth
+	texHeight byteSize rwBindings |
+
 	texWidth := 16.
 	texHeight := 16.
 	byteSize := texWidth * texHeight * FFIUInt32 externalTypeSize. "R8G8B8A8"
@@ -462,43 +451,40 @@ SDL3ComputePipelineTest >> test06StorageTextures [
 	rwBindings := FFIArray newType: SDL3GPUStorageTextureReadWriteBinding size: 1.
 	rwBindings first texture: resultTexture; cycle: false.
 
-	computePass := commandBuffer beginGPUComputePassStorageTextureBindings: rwBindings numStorageTextureBindings: 1 storageBufferBindings: nil numStorageBufferBindings: 0.
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass dispatchWorkgroupCountX: 1 y: 1 z: 1.
-	computePass end.
+	commandBuffer computePassTextures: rwBindings computeStorageBuffers: #() do: [ :computePass |
+		computePass pipeline: computePipeline.
+		computePass dispatchX: 1 y: 1 z: 1 ].
 	commandBuffer submit.
 	
 	"3. Download results"
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUTextureSource: (SDL3GPUTextureRegion new texture: resultTexture; w: texWidth; h: texHeight; d: 1; yourself)
-		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadTexture: (SDL3GPUTextureRegion new texture: resultTexture; w: texWidth; h: texHeight; d: 1; yourself)
+			destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"4. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
-	
-	self assert: (resultData at: 1) equals: 0. "R"
-	self assert: (resultData at: 2) equals: 0. "G"
-	self assert: (resultData at: 3) equals: 0. "B"
-	self assert: (resultData at: 4) equals: 255. "A"
-
-	self assert: (resultData at: byteSize - 3) equals: 239. "R (15/16 * 255 = 239.0625)"
-	self assert: (resultData at: byteSize - 2) equals: 239. "G"
-	self assert: (resultData at: byteSize - 1) equals: 0. "B"
-	self assert: (resultData at: byteSize) equals: 255. "A"
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
+		
+		self assert: (resultData at: 1) equals: 0. "R"
+		self assert: (resultData at: 2) equals: 0. "G"
+		self assert: (resultData at: 3) equals: 0. "B"
+		self assert: (resultData at: 4) equals: 255. "A"
+		
+		self assert: (resultData at: byteSize - 3) equals: 239. "R (15/16 * 255 = 239.0625)"
+		self assert: (resultData at: byteSize - 2) equals: 239. "G"
+		self assert: (resultData at: byteSize - 1) equals: 0. "B"
+		self assert: (resultData at: byteSize) equals: 255. "A" ].
 
 	"Cleanup"
-	gpuDevice releaseGPUComputePipeline: computePipeline.
-	gpuDevice releaseGPUTexture: resultTexture.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	computePipeline release.
+	resultTexture release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -506,7 +492,8 @@ SDL3ComputePipelineTest >> test07SharedMemory [
 	"Case 7: Shared Memory
 	Demonstrates a parallel reduction within a workgroup."
 
-	| inputData inputBuffer resultBuffer computePipeline commandBuffer computePass transferBuffer mappedAddress resultData numElements numWorkgroups byteSize rwBindings roBindings |
+	| inputData inputBuffer resultBuffer computePipeline commandBuffer transferBuffer resultData
+	numElements numWorkgroups byteSize rwBindings roBindings |
 	
 	numElements := 1024. "16 workgroups of 64 threads each"
 	numWorkgroups := SDL3TestComputeSharedMemoryShaderSource dispatchWorkgroupCountXFor: numElements.
@@ -527,18 +514,17 @@ SDL3ComputePipelineTest >> test07SharedMemory [
 	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
 
 	"3. Upload input data"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: inputData to: mappedAddress size: byteSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: inputData to: mappedAddress size: byteSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
 	
 	"A. Upload"
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: inputBuffer; offset: 0; size: byteSize; yourself)
-		cycle: false;
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: inputBuffer; offset: 0; size: byteSize; yourself)
+			cycle: false ].
 
 	"B. Compute"
 	computePipeline := SDL3TestComputeSharedMemoryShaderSource newComputePipelineAmong: shaderFormats device: gpuDevice.
@@ -548,41 +534,38 @@ SDL3ComputePipelineTest >> test07SharedMemory [
 	roBindings := FFIArray newType: ExternalAddress size: 1.
 	roBindings at: 1 put: inputBuffer getHandle.
 
-	computePass := commandBuffer beginGPUComputePassStorageTextureBindings: nil numStorageTextureBindings: 0 storageBufferBindings: rwBindings numStorageBufferBindings: 1.
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass bindGPUComputeStorageBuffersFirstSlot: 0 storageBuffers: roBindings numBindings: 1.
-	computePass dispatchWorkgroupCountX: numWorkgroups y: 1 z: 1.
-	computePass end.
+	commandBuffer computePassTextures: #() computeStorageBuffers: rwBindings do: [ :computePass |
+		computePass pipeline: computePipeline.
+		computePass computeStorageBuffers: roBindings slot: 0.
+		computePass dispatchX: numWorkgroups y: 1 z: 1 ].
 	
 	commandBuffer submit.
 
 	"4. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: numWorkgroups * FFIFloat32 externalTypeSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUBufferSource: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: numWorkgroups * FFIFloat32 externalTypeSize; yourself)
-		destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadBuffer: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: numWorkgroups * FFIFloat32 externalTypeSize; yourself)
+			destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"5. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numWorkgroups.
-	
-	"Every workgroup of 64 threads should produce the sum of 64 ones = 64.0"
-	1 to: numWorkgroups do: [ :i |
-		self assert: (resultData at: i) equals: 64.0 ].
-	
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numWorkgroups.
+		
+		"Every workgroup of 64 threads should produce the sum of 64 ones = 64.0"
+		1 to: numWorkgroups do: [ :i |
+		self assert: (resultData at: i) equals: 64.0 ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUComputePipeline: computePipeline.
-	gpuDevice releaseGPUBuffer: inputBuffer.
-	gpuDevice releaseGPUBuffer: resultBuffer.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	computePipeline release.
+	inputBuffer release.
+	resultBuffer release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -590,8 +573,9 @@ SDL3ComputePipelineTest >> test08IndirectDispatch [
 	"Case 8: Indirect Dispatch
 	Demonstrates reading workgroup counts from a GPU buffer."
 
-	| indirectData indirectBuffer inputData inputBuffer resultBuffer computePipeline commandBuffer computePass transferBuffer mappedAddress resultData numElements byteSize rwBindings roBindings |
-	
+	| indirectData indirectBuffer inputData inputBuffer resultBuffer computePipeline commandBuffer
+	transferBuffer resultData numElements byteSize rwBindings roBindings |
+
 	numElements := 1024.
 	byteSize := numElements * FFIFloat32 externalTypeSize.
 
@@ -619,24 +603,21 @@ SDL3ComputePipelineTest >> test08IndirectDispatch [
 	
 	"4. Upload data"
 	transferBuffer := gpuDevice newUploadTransferBuffer: SDL3GPUIndirectDispatchCommand structureSize + byteSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	
-	"Upload indirect command at offset 0"
-	LibC memCopy: indirectData to: mappedAddress size: SDL3GPUIndirectDispatchCommand structureSize.
-	"Upload input data at offset after indirect struct"
-	LibC memCopy: inputData to: mappedAddress + SDL3GPUIndirectDispatchCommand structureSize size: byteSize.
-	
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		"Upload indirect command at offset 0"
+		LibC memCopy: indirectData to: mappedAddress size: SDL3GPUIndirectDispatchCommand structureSize.
+		"Upload input data at offset after indirect struct"
+		LibC memCopy: inputData to: mappedAddress + SDL3GPUIndirectDispatchCommand structureSize size: byteSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: indirectBuffer; offset: 0; size: SDL3GPUIndirectDispatchCommand structureSize; yourself)
-		cycle: false;
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: SDL3GPUIndirectDispatchCommand structureSize; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: inputBuffer; offset: 0; size: byteSize; yourself)
-		cycle: false;
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: indirectBuffer; offset: 0; size: SDL3GPUIndirectDispatchCommand structureSize; yourself)
+			cycle: false;
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: SDL3GPUIndirectDispatchCommand structureSize; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: inputBuffer; offset: 0; size: byteSize; yourself)
+			cycle: false ].
 
 	"5. Compute"
 	computePipeline := SDL3TestComputeMathShaderSource newComputePipelineAmong: shaderFormats device: gpuDevice.
@@ -646,39 +627,35 @@ SDL3ComputePipelineTest >> test08IndirectDispatch [
 	roBindings := FFIArray newType: ExternalAddress size: 1.
 	roBindings at: 1 put: inputBuffer getHandle.
 
-	computePass := commandBuffer beginGPUComputePassStorageTextureBindings: nil numStorageTextureBindings: 0 storageBufferBindings: rwBindings numStorageBufferBindings: 1.
-	computePass bindGPUComputePipeline: computePipeline.
-	computePass bindGPUComputeStorageBuffersFirstSlot: 0 storageBuffers: roBindings numBindings: 1.
-	
-	computePass dispatchGPUComputeIndirectBuffer: indirectBuffer offset: 0.
-	computePass end.
+	commandBuffer computePassTextures: #() computeStorageBuffers: rwBindings do: [ :computePass |
+		computePass pipeline: computePipeline.
+		computePass computeStorageBuffers: roBindings slot: 0.
+		computePass dispatchIndirectBuffer: indirectBuffer offset: 0 ].
 	
 	commandBuffer submit.
 
 	"6. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUBufferSource: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
-		destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadBuffer: (SDL_GPUBufferRegion new buffer: resultBuffer; offset: 0; size: byteSize; yourself)
+			destination: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"7. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numElements.
-	1 to: numElements do: [ :i |
-		self assert: (resultData at: i) equals: (i * 2) asFloat ].
-	
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIFloat32 size: numElements.
+		1 to: numElements do: [ :i |
+		self assert: (resultData at: i) equals: (i * 2) asFloat ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUComputePipeline: computePipeline.
-	gpuDevice releaseGPUBuffer: indirectBuffer.
-	gpuDevice releaseGPUBuffer: inputBuffer.
-	gpuDevice releaseGPUBuffer: resultBuffer.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	computePipeline release.
+	indirectBuffer release.
+	inputBuffer release.
+	resultBuffer release.
+	transferBuffer release
 ]

--- a/src/SDL3-Demos/SDL3AnimatedCursorDemo.class.st
+++ b/src/SDL3-Demos/SDL3AnimatedCursorDemo.class.st
@@ -39,28 +39,6 @@ SDL3AnimatedCursorDemo >> close [
 	super close
 ]
 
-{ #category : 'initialization' }
-SDL3AnimatedCursorDemo >> createAnimatedCursorFromFrames: frames delays: anArray hotspot: h [
-
-	| frameInfos |
-	frameInfos := FFIExternalArray
-		              externalNewType: SDL3CursorFrameInfo
-		              size: frames size.
-	frameInfos autoRelease.
-
-	frames doWithIndex: [ :surface :i | 
-		| info |
-		info := frameInfos at: i.
-		info surface: surface.
-		info duration: (anArray at: i) ].
-
-	^ SDL3Cursor
-		  unsafeNewAnimatedFrames: frameInfos
-		  frameCount: frames size
-		  hotX: h x
-		  hotY: h y
-]
-
 { #category : 'accessing' }
 SDL3AnimatedCursorDemo >> crosshairSize [
 
@@ -324,10 +302,7 @@ SDL3AnimatedCursorDemo >> initialExtent [
 SDL3AnimatedCursorDemo >> newAnimatedCursorFromFrames: frames delays: anArray hotspot: h [
 
 	| frameInfos |
-	frameInfos := FFIExternalArray
-		              externalNewType: SDL3CursorFrameInfo
-		              size: frames size.
-	frameInfos autoRelease.
+	frameInfos := SDL_CursorFrameInfo safeNewArray: frames size.
 
 	frames doWithIndex: [ :surface :i | 
 		| info |

--- a/src/SDL3-GPUDemos/SDL3BumpedSinusoidalWrapShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3BumpedSinusoidalWrapShaderSource.class.st
@@ -139,9 +139,9 @@ float4 main(PSInput input) : SV_Target
    // Sample texture with warp offset
    float2 warpOffset = W(sp.xy, time) / 8.0;
    float3 texCol = InputTexture.Sample(InputSampler, sp.xy + warpOffset).rgb * input.color.rgb;
-   
+
    texCol *= texCol; // Rough sRGB to linear conversion
-   
+
    // Color processing
    texCol = smoothstep(0.05, 0.75, pow(texCol, float3(0.75, 0.8, 0.85)));
 

--- a/src/SDL3-GPUDemos/SDL3CRTEffectShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3CRTEffectShaderSource.class.st
@@ -63,20 +63,20 @@ float4 main(PSInput input) : SV_Target {
    float2 uv = input.uv;
 
    float warp_amount = cos(time);
-   
+
    float2 delta = uv - 0.5;
    float warp_factor = dot(delta, delta) * warp_amount;
    uv += delta * warp_factor;
-   
+
    float scanline = sin(uv.y * resolution.y * PI) * 0.5 + 0.5;
    scanline = lerp(1.0, scanline, scan_line_amount * 0.5);
-   
+
    float grille = fmod(uv.x * resolution.x, 3.0) < 1.5 ? 0.95 : 1.05;
    grille = lerp(1.0, grille, grille_amount * 0.5);
-   
+
    float4 color = InputTexture.Sample(InputSampler, input.uv) * input.color;
    color.rgb *= scanline * grille;
-   
+
    float2 v_uv = uv * (1.0 - uv.xy);
    float vignette = v_uv.x * v_uv.y * 15.0;
    vignette = lerp(1.0, vignette, vignette_amount * 0.7);

--- a/src/SDL3-GPUDemos/SDL3CloudsShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3CloudsShaderSource.class.st
@@ -69,19 +69,19 @@ float noise(float2 p)
 {
    const float K1 = 0.366025404; // (sqrt(3)-1)/2;
    const float K2 = 0.211324865; // (3-sqrt(3))/6;
-   
+
    float2 i = floor(p + (p.x + p.y) * K1);
    float2 a = p - i + (i.x + i.y) * K2;
    // HLSL ternary vector selection
    float2 o = (a.x > a.y) ? float2(1.0, 0.0) : float2(0.0, 1.0);
-   
+
    float2 b = a - o + K2;
    float2 c = a - 1.0 + 2.0 * K2;
-   
+
    float3 h = max(0.5 - float3(dot(a, a), dot(b, b), dot(c, c)), 0.0);
-   
+
    float3 n = h * h * h * h * float3(dot(a, hash(i + 0.0)), dot(b, hash(i + o)), dot(c, hash(i + 1.0)));
-   
+
    // In HLSL float3(70.0) constructs a vector where all components are 70.0
    return dot(n, float3(70.0, 70.0, 70.0));
 }
@@ -111,26 +111,26 @@ float4 main(PSInput input) : SV_Target
 {
    // Map input UV to p (0 to 1)
    float2 p = input.uv;
-   
+
    // Correct Aspect Ratio using the resolution uniform
    float2 uv = p * float2(resolution.x / resolution.y, 1.0);
-   
+
    float timeVal = time * speed;
    float q = fbm(uv * cloudscale * 0.5);
-   
+
    // Ridged noise shape
    float r = 0.0;
    uv *= cloudscale;
    uv -= q - timeVal;
    float weight = 0.8;
-   
+
    for (int i = 0; i < 8; i++)
    {
        r += abs(weight * noise(uv));
        uv = mul(uv, m) + timeVal;
        weight *= 0.7;
    }
-   
+
    // Noise shape
    float f = 0.0;
    // Recalculate UV for next pass
@@ -138,16 +138,16 @@ float4 main(PSInput input) : SV_Target
    uv *= cloudscale;
    uv -= q - timeVal;
    weight = 0.7;
-   
+
    for (int j = 0; j < 8; j++)
    {
        f += weight * noise(uv);
        uv = mul(uv, m) + timeVal;
        weight *= 0.6;
    }
-   
+
    f *= r + f;
-   
+
    // Noise colour
    float c = 0.0;
    timeVal = time * speed * 2.0;
@@ -155,14 +155,14 @@ float4 main(PSInput input) : SV_Target
    uv *= cloudscale * 2.0;
    uv -= q - timeVal;
    weight = 0.4;
-   
+
    for (int k = 0; k < 7; k++)
    {
        c += weight * noise(uv);
        uv = mul(uv, m) + timeVal;
        weight *= 0.6;
    }
-   
+
    // Noise ridge colour
    float c1 = 0.0;
    timeVal = time * speed * 3.0;
@@ -170,24 +170,24 @@ float4 main(PSInput input) : SV_Target
    uv *= cloudscale * 3.0;
    uv -= q - timeVal;
    weight = 0.4;
-   
+
    for (int l = 0; l < 7; l++)
    {
        c1 += abs(weight * noise(uv));
        uv = mul(uv, m) + timeVal;
        weight *= 0.6;
    }
-   
+
    c += c1;
-   
+
    // HLSL mix -> lerp
    float3 skycolour = lerp(skycolour2, skycolour1, p.y);
    float3 cloudcolour = float3(1.1, 1.1, 0.9) * clamp((clouddark + cloudlight * c), 0.0, 1.0);
-  
+
    f = cloudcover + cloudalpha * f * r;
-   
+
    float3 result = lerp(skycolour, clamp(skytint * skycolour + cloudcolour, 0.0, 1.0), clamp(f + c, 0.0, 1.0));
-   
+
    //return float4(result, 1.0) * input.color;
    return lerp(float4(result, 1.0) * input.color, (InputTexture.Sample(InputSampler, input.uv) * input.color), 0.5);
 

--- a/src/SDL3-GPUDemos/SDL3DotsHalftoneShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3DotsHalftoneShaderSource.class.st
@@ -56,11 +56,11 @@ float GetDotScreen(float2 uv, float scale)
 {
    // Convert 0..1 UV to Centered Pixel Coordinates
    float2 p = (uv - 0.5f) * resolution;
-   
+
    // Rotate
    // Note: HLSL standard is mul(vector, matrix) for row vectors
    float2 q = p * scale;
-   
+
    return (sin(q.x) * sin(q.y)) * 4.0f;
 }
 
@@ -76,18 +76,18 @@ float4 main(PSInput input) : SV_Target
 {
    // 1. Sample Texture
    float3 col = (InputTexture.Sample(InputSampler, input.uv) * input.color).rgb;
-   
+
    // 2. Grayscale
    float grey = GetGreyScale(col);
-   
+
    // 3. Calculate Parameters
    float scale = 1.0f + 0.3f * sin(time / 10.0f);
-   
+
    // 4. Apply Dot Screen Pattern
    // The original code creates a vec3 where all channels are identical
    float pattern = GetDotScreen(input.uv, scale);
    float finalVal = grey * 10.0f - 5.0f + pattern;
-   
+
    col = float3(finalVal, finalVal, finalVal);
 
    return float4(col, 1.0f);

--- a/src/SDL3-GPUDemos/SDL3GPUBoidsDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUBoidsDemo.class.st
@@ -33,35 +33,35 @@ Class {
 SDL3GPUBoidsDemo >> close [
 
 	boidsBufferPing ifNotNil: [
-		gpuDevice releaseGPUBuffer: boidsBufferPing.
+		boidsBufferPing release.
 		boidsBufferPing := nil ].
-	
+
 	boidsBufferPong ifNotNil: [
-		gpuDevice releaseGPUBuffer: boidsBufferPong.
+		boidsBufferPong release.
 		boidsBufferPong := nil ].
 
 	huesBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: huesBuffer.
+		huesBuffer release.
 		huesBuffer := nil ].
 
 	vertexBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: vertexBuffer.
+		vertexBuffer release.
 		vertexBuffer := nil ].
 
 	indexBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: indexBuffer.
+		indexBuffer release.
 		indexBuffer := nil ].
 
 	boidsComputePipeline ifNotNil: [
-		gpuDevice releaseGPUComputePipeline: boidsComputePipeline.
+		boidsComputePipeline release.
 		boidsComputePipeline := nil ].
 
 	geometryComputePipeline ifNotNil: [
-		gpuDevice releaseGPUComputePipeline: geometryComputePipeline.
+		geometryComputePipeline release.
 		geometryComputePipeline := nil ].
 
 	renderPipeline ifNotNil: [
-		gpuDevice releaseGPUGraphicsPipeline: renderPipeline.
+		renderPipeline release.
 		renderPipeline := nil ].
 
 	super close
@@ -88,58 +88,49 @@ SDL3GPUBoidsDemo >> computeSimulation [
 
 	"Geometry Pass"
 	self doGeometryPassWith: commandBuffer input: currentBoidsBuffer.
-	
+
 	commandBuffer submit
 ]
 
 { #category : 'rendering' }
-SDL3GPUBoidsDemo >> doGeometryPassWith: aCommandBuffer input: inputBuffer [
+SDL3GPUBoidsDemo >> doGeometryPassWith: commandBuffer input: inputBuffer [
 
-	| computePass |
-	self pushGeometryUniformsTo: aCommandBuffer.
+	self pushGeometryUniformsTo: commandBuffer.
 
-	storageBufferBinding first
-		buffer: vertexBuffer;
-		cycle: false.
+	storageBufferBinding first buffer: vertexBuffer.
 
-	computePass := aCommandBuffer
-					  beginGPUComputePassStorageTextureBindings: #()
-					  storageBufferBindings: storageBufferBinding.
+	commandBuffer computePassTextures: #() computeStorageBuffers: storageBufferBinding do: [ :computePass |
+		storageBuffers
+			at: 1 put: inputBuffer getHandle;
+			at: 2 put: huesBuffer getHandle.
 
-	storageBuffers at: 1 put: inputBuffer getHandle.
-	storageBuffers at: 2 put: huesBuffer getHandle.
-
-	computePass
-		bindGPUComputePipeline: geometryComputePipeline;
-		bindGPUComputeStorageBuffersFirstSlot: 0
-		storageBuffers: storageBuffers;
-		dispatchWorkgroupCountX: numBoids + 63 // 64
-		y: 1
-		z: 1;
-		end
+		computePass
+			pipeline: geometryComputePipeline;
+			computeStorageBuffers: storageBuffers slot: 0;
+			dispatchX: numBoids + 63 // 64
+			y: 1
+			z: 1 ]
 ]
 
 { #category : 'rendering' }
-SDL3GPUBoidsDemo >> doPhysicsPassWith: aCommandBuffer input: inputBuffer output: outputBuffer [
+SDL3GPUBoidsDemo >> doPhysicsPassWith: commandBuffer input: inputBuffer output: outputBuffer [
 
 	| extent |
 	extent := window pixelExtent.
 
 	"Aspect ratio bounds calculation: keep the minimum dimension mapped to [-1, 1]"
 	extent x > extent y
-		ifTrue: [ 
+		ifTrue: [
 			boidsUniforms boundX: extent x asFloat / extent y asFloat.
 			boidsUniforms boundY: 1.0 ]
-		ifFalse: [ 
+		ifFalse: [
 			boidsUniforms boundX: 1.0.
 			boidsUniforms boundY: extent y asFloat / extent x asFloat ].
 
 	boidsUniforms time: Time millisecondClockValue / 1000.0.
 
-	aCommandBuffer
-		pushGPUComputeUniformDataSlotIndex: 0
-		data: boidsUniforms
-		length: boidsUniforms class structureSize.
+	commandBuffer
+		pushComputeUniform: boidsUniforms slot: 0.
 
 	storageBuffers at: 1 put: inputBuffer getHandle.
 
@@ -147,46 +138,32 @@ SDL3GPUBoidsDemo >> doPhysicsPassWith: aCommandBuffer input: inputBuffer output:
 		buffer: outputBuffer;
 		cycle: false.
 
-	physicsStorageBuffers at: 1 put: inputBuffer getHandle.
+	commandBuffer computePassTextures: #() computeStorageBuffers: storageBufferBinding do: [ :computePass |
+		physicsStorageBuffers at: 1 put: inputBuffer getHandle.
 
-	(aCommandBuffer
-		beginGPUComputePassStorageTextureBindings: #()
-		storageBufferBindings: storageBufferBinding)
-		bindGPUComputePipeline: boidsComputePipeline;
-		bindGPUComputeStorageBuffersFirstSlot: 0
-		storageBuffers: physicsStorageBuffers;
-		dispatchWorkgroupCountX: numBoids + 63 // 64
-		y: 1
-		z: 1;
-		end
+		computePass
+			pipeline: boidsComputePipeline;
+			computeStorageBuffers: physicsStorageBuffers slot: 0;
+			dispatchX: numBoids + 63 // 64
+			y: 1
+			z: 1 ]
 ]
 
 { #category : 'rendering' }
-SDL3GPUBoidsDemo >> doRenderPassesOn: swapchainTexture with: aCommandBuffer [
+SDL3GPUBoidsDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 
-	| renderPass |
 	renderColorTargetInfos first texture: swapchainTexture.
 
-	renderPass := aCommandBuffer
-				 beginGPURenderPassColorTargetInfos:
-				 renderColorTargetInfos
-				 depthStencilTargetInfo: nil.
-
-	renderPass bindGPUGraphicsPipeline: renderPipeline.
-
-	renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings.
-	renderPass
-		bindGPUIndexBufferBinding: indexBufferBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-
-	renderPass
-		drawGPUIndexedPrimitivesNumIndices: numBoids * 3
-		numInstances: 1
-		firstIndex: 0
-		vertexOffset: 0
-		firstInstance: 0.
-
-	renderPass end
+	commandBuffer renderPassTargets: renderColorTargetInfos do: [ :renderPass |
+		renderPass
+			pipeline: renderPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			indexBuffer16Bit: indexBufferBinding;
+			drawIndexedPrimitives: numBoids * 3
+			instances: 1
+			firstIndex: 0
+			vertexOffset: 0
+			firstInstance: 0 ]
 ]
 
 { #category : 'private' }
@@ -195,7 +172,7 @@ SDL3GPUBoidsDemo >> generateInitialBoids [
 	| random boids |
 	random := Random seed: 7.
 	boids := FFIArray newType: SDL3GPUBoidsBoid size: numBoids.
-	1 to: numBoids do: [ :i | 
+	1 to: numBoids do: [ :i |
 		| boid |
 		boid := boids at: i.
 		boid
@@ -224,7 +201,7 @@ SDL3GPUBoidsDemo >> handleKeyDown: aKeyboardEvent [
 
 	| key |
 	key := aKeyboardEvent key.
-	
+
 	"Weights"
 	key = SDLK_Q asInteger ifTrue: [ ^ boidsUniforms separationWeight: boidsUniforms separationWeight + 0.1 ].
 	key = SDLK_A asInteger ifTrue: [ ^ boidsUniforms separationWeight: ((boidsUniforms separationWeight - 0.1) max: 0) ].
@@ -232,7 +209,7 @@ SDL3GPUBoidsDemo >> handleKeyDown: aKeyboardEvent [
 	key = SDLK_S asInteger ifTrue: [ ^ boidsUniforms alignmentWeight: ((boidsUniforms alignmentWeight - 0.1) max: 0) ].
 	key = SDLK_E asInteger ifTrue: [ ^ boidsUniforms cohesionWeight: boidsUniforms cohesionWeight + 0.1 ].
 	key = SDLK_D asInteger ifTrue: [ ^ boidsUniforms cohesionWeight: ((boidsUniforms cohesionWeight - 0.1) max: 0) ].
-	
+
 	"Radii"
 	key = SDLK_T asInteger ifTrue: [ ^ boidsUniforms neighborRadius: boidsUniforms neighborRadius + 0.01 ].
 	key = SDLK_G asInteger ifTrue: [ ^ boidsUniforms neighborRadius: ((boidsUniforms neighborRadius - 0.01) max: 0.01) ].
@@ -251,18 +228,14 @@ SDL3GPUBoidsDemo >> initialize [
 
 	numBoids := 1000.
 
-	vertexBufferBindings := FFIExternalArray externalNewType: SDL_GPUBufferBinding size: 1.
-	vertexBufferBindings autoRelease.
+	vertexBufferBindings := SDL_GPUBufferBinding safeNewArray: 1.
 
-	storageBuffers := FFIExternalArray externalNewType: ExternalAddress size: 2.
-	storageBuffers autoRelease.
+	storageBuffers := ExternalAddress safeNewArray: 2.
 
-	storageBufferBinding := FFIExternalArray externalNewType: SDL_GPUStorageBufferReadWriteBinding size: 1.
-	storageBufferBinding autoRelease.
+	storageBufferBinding := SDL3GPUStorageBufferReadWriteBinding safeNewArray: 1.
 
 	"Simulation defaults"
-	boidsUniforms := SDL3GPUBoidsUniforms externalNew.
-	boidsUniforms autoRelease.
+	boidsUniforms := SDL3GPUBoidsUniforms safeNew.
 	boidsUniforms
 		numBoids: numBoids;
 		separationWeight: 1.5;
@@ -275,22 +248,42 @@ SDL3GPUBoidsDemo >> initialize [
 		damping: 0.99;
 		deltaTime: loop periodAsSeconds.
 
-	geometryUniforms := SDL3GPUBoidsGeometryUniforms externalNew.
-	geometryUniforms autoRelease.
+	geometryUniforms := SDL3GPUBoidsGeometryUniforms safeNew.
 
-	physicsStorageBuffers := FFIExternalArray
-					externalNewType: ExternalAddress
-					size: 1.
-	physicsStorageBuffers autoRelease.
+	physicsStorageBuffers := ExternalAddress safeNewArray: 1.
+	renderColorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
+	renderColorTargetInfos first beClear: Color black
+]
 
-	renderColorTargetInfos := FFIExternalArray
-					 externalNewType: SDL_GPUColorTargetInfo
-					 size: 1.
-	renderColorTargetInfos autoRelease.
-	renderColorTargetInfos first
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR;
-		updateClearColorFrom: Color black
+{ #category : 'initialization' }
+SDL3GPUBoidsDemo >> initializeBoidsBuffers [
+
+	| boidsSize |
+	boidsSize := numBoids * SDL3GPUBoidsBoid structureSize.
+
+	boidsBufferPing := gpuDevice
+		                   newGPUBufferUsage:
+			                   SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE
+			                   | SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ
+		                   size: boidsSize.
+
+	boidsBufferPong := gpuDevice
+		                   newGPUBufferUsage:
+			                   SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE
+			                   | SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ
+		                   size: boidsSize.
+
+	currentBoidsBuffer := boidsBufferPing
+]
+
+{ #category : 'initialization' }
+SDL3GPUBoidsDemo >> initializeBuffers [
+
+	self
+		initializeBoidsBuffers;
+		initializeHuesBuffer;
+		initializeVertexBuffers;
+		initializeIndexBuffer
 ]
 
 { #category : 'initialization' }
@@ -306,9 +299,27 @@ SDL3GPUBoidsDemo >> initializeComputeResources [
 ]
 
 { #category : 'initialization' }
+SDL3GPUBoidsDemo >> initializeHuesBuffer [
+
+	huesBuffer := gpuDevice
+		              newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ
+		              size: numBoids * FFIFloat32 externalTypeSize
+]
+
+{ #category : 'initialization' }
+SDL3GPUBoidsDemo >> initializeIndexBuffer [
+
+	indexBuffer := gpuDevice
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+		               size: numBoids * 3 * 2. "16-bit"
+
+	indexBufferBinding := SDL_GPUBufferBinding buffer: indexBuffer offset: 0
+]
+
+{ #category : 'initialization' }
 SDL3GPUBoidsDemo >> initializeRenderPipeline [
 
-	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets pipelineCreateInfo |
+	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets |
 	vertexShader := SDL3GPUBoidsVertexShaderSource
 						newShaderAmong: shaderFormats
 						device: gpuDevice.
@@ -319,48 +330,40 @@ SDL3GPUBoidsDemo >> initializeRenderPipeline [
 	vertexBindings := self newBoidsVertexBindings.
 	vertexAttributes := self newBoidsVertexAttributes.
 
-	colorTargets := self newColorTargetDescriptions: 1.
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
 	colorTargets first
 		format: (gpuDevice getGPUSwapchainTextureFormatIntoWindow: window);
-		blendState: self newAlphaBlendState.
+		blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
 
-	pipelineCreateInfo := SDL3GPUGraphicsPipelineCreateInfo externalNew
-							 autoRelease.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader;
-		fragmentShader: fragmentShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: colorTargets size.
-	pipelineCreateInfo vertexInputState
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: vertexBindings size;
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: vertexAttributes size.
+	renderPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
-	renderPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo:
-						 pipelineCreateInfo.
-
-	gpuDevice releaseGPUShader: vertexShader.
-	gpuDevice releaseGPUShader: fragmentShader.
-	vertexBindings free.
-	vertexAttributes free.
-	colorTargets free
+	vertexShader release.
+	fragmentShader release
 ]
 
-{ #category : 'private' }
-SDL3GPUBoidsDemo >> newAlphaBlendState [
+{ #category : 'initialization' }
+SDL3GPUBoidsDemo >> initializeVertexBuffers [
 
-	^ SDL_GPUColorTargetBlendState new
-		 enableBlend: true;
-		 srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-		 dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-		 colorBlendOp: SDL_GPU_BLENDOP_ADD;
-		 srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-		 dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-		 alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-		 yourself
+	vertexBuffer := gpuDevice
+		                newGPUBufferUsage:
+			                SDL_GPU_BUFFERUSAGE_VERTEX
+			                | SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE
+		                size: numBoids * 3 * SDL3GPUBoidsVertex structureSize.
+
+	vertexBufferBindings first
+		buffer: vertexBuffer;
+		offset: 0.
+
+	storageBufferBinding first
+		buffer: vertexBuffer;
+		cycle: false
 ]
 
 { #category : 'private' }
@@ -398,58 +401,6 @@ SDL3GPUBoidsDemo >> newBoidsVertexBindings [
 	^ vertexBindings
 ]
 
-{ #category : 'initialization' }
-SDL3GPUBoidsDemo >> newBuffers [
-
-	"Boids Buffers (Physics Ping-Pong)"
-
-	boidsBufferPing := gpuDevice
-						  newGPUBufferUsage:
-							  SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE
-							  | SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ
-						  size: numBoids * SDL3GPUBoidsBoid structureSize.
-
-	boidsBufferPong := gpuDevice
-						  newGPUBufferUsage:
-							  SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE
-							  | SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ
-						  size: numBoids * SDL3GPUBoidsBoid structureSize.
-
-	currentBoidsBuffer := boidsBufferPing.
-
-	"Hues Buffer (Static)"
-	huesBuffer := gpuDevice
-					 newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ
-					 size: numBoids * FFIFloat32 externalTypeSize. "4 bytes per float"
-
-	"Vertex Buffer (Geometry Output)"
-	"3 vertices per boid"
-	vertexBuffer := gpuDevice
-						newGPUBufferUsage:
-							SDL_GPU_BUFFERUSAGE_VERTEX
-							| SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE
-						size: numBoids * 3 * SDL3GPUBoidsVertex structureSize.
-
-	vertexBufferBindings first
-		buffer: vertexBuffer;
-		offset: 0.
-
-	storageBufferBinding first
-		buffer: vertexBuffer;
-		cycle: false.
-
-	"Index Buffer"
-	"3 indices per boid"
-	indexBuffer := gpuDevice
-					  newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
-					  size: numBoids * 3 * 2. "16-bit"
-
-	indexBufferBinding := SDL_GPUBufferBinding externalNew
-							 buffer: indexBuffer;
-							 yourself.
-	indexBufferBinding autoRelease
-]
-
 { #category : 'lifecycle' }
 SDL3GPUBoidsDemo >> open [
 	"Run headless with:
@@ -457,24 +408,24 @@ SDL3GPUBoidsDemo >> open [
 	"
 
 	super open.
-	self newBuffers.
+	self initializeBuffers.
 	self uploadInitialData.
 	self initializeComputeResources.
 	self initializeRenderPipeline
 ]
 
 { #category : 'private' }
-SDL3GPUBoidsDemo >> pushGeometryUniformsTo: aCommandBuffer [
+SDL3GPUBoidsDemo >> pushGeometryUniformsTo: commandBuffer [
 
 	| extent |
 	extent := window extent.
 
 	"Aspect ratio bounds calculation: keep the minimum dimension mapped to [-1, 1]"
 	extent x > extent y
-		ifTrue: [ 
+		ifTrue: [
 			geometryUniforms boundX: extent x asFloat / extent y asFloat.
 			geometryUniforms boundY: 1.0 ]
-		ifFalse: [ 
+		ifFalse: [
 			geometryUniforms boundX: 1.0.
 			geometryUniforms boundY: extent y asFloat / extent x asFloat ].
 
@@ -482,10 +433,8 @@ SDL3GPUBoidsDemo >> pushGeometryUniformsTo: aCommandBuffer [
 		numBoids: numBoids;
 		boidRadius: 0.05.
 
-	aCommandBuffer
-		pushGPUComputeUniformDataSlotIndex: 0
-		data: geometryUniforms
-		length: geometryUniforms class structureSize
+	commandBuffer
+		pushComputeUniform: geometryUniforms slot: 0
 ]
 
 { #category : 'hooks' }
@@ -499,7 +448,7 @@ SDL3GPUBoidsDemo >> step [
 SDL3GPUBoidsDemo >> updatedTitle [
 
 	^ super updatedTitle, (' - Count: {1} | Sep: {2} Ali: {3} Coh: {4} | Rad: {5}/{6} | MaxV: {7}' format: {
-		numBoids. 
+		numBoids.
 		boidsUniforms separationWeight printShowingDecimalPlaces: 1.
 		boidsUniforms alignmentWeight printShowingDecimalPlaces: 1.
 		boidsUniforms cohesionWeight printShowingDecimalPlaces: 1.
@@ -507,108 +456,6 @@ SDL3GPUBoidsDemo >> updatedTitle [
 		boidsUniforms neighborRadius printShowingDecimalPlaces: 2.
 		boidsUniforms maxVelocity printShowingDecimalPlaces: 2
 	})
-]
-
-{ #category : 'private' }
-SDL3GPUBoidsDemo >> uploadBoids: boids [
-
-	| bSize bTransfer mappedAddress |
-	bSize := numBoids * SDL3GPUBoidsBoid structureSize.
-	bTransfer := gpuDevice newUploadTransferBuffer: bSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: bTransfer cycle: false.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
-	LibC memCopy: boids getHandle to: mappedAddress size: bSize.
-	gpuDevice unmapGPUTransferBuffer: bTransfer.
-
-	gpuDevice acquireGPUCommandBuffer in: [ :commandBuffer | 
-		| copyPass |
-		copyPass := commandBuffer beginGPUCopyPass.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: bTransfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: boidsBufferPing;
-					offset: 0;
-					size: bSize;
-					yourself)
-			cycle: false.
-		copyPass end.
-		commandBuffer submit ].
-
-	gpuDevice releaseGPUTransferBuffer: bTransfer
-]
-
-{ #category : 'private' }
-SDL3GPUBoidsDemo >> uploadHues: hues [
-
-	| hSize hTransfer mappedAddress |
-	hSize := numBoids * FFIFloat32 externalTypeSize.
-	hTransfer := gpuDevice newUploadTransferBuffer: hSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: hTransfer cycle: false.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
-	LibC memCopy: hues getHandle to: mappedAddress size: hSize.
-	gpuDevice unmapGPUTransferBuffer: hTransfer.
-
-	gpuDevice acquireGPUCommandBuffer in: [ :commandBuffer | 
-		| copyPass |
-		copyPass := commandBuffer beginGPUCopyPass.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: hTransfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: huesBuffer;
-					offset: 0;
-					size: hSize;
-					yourself)
-			cycle: false.
-		copyPass end.
-		commandBuffer submit ].
-
-	gpuDevice releaseGPUTransferBuffer: hTransfer
-]
-
-{ #category : 'private' }
-SDL3GPUBoidsDemo >> uploadIndices [
-
-	| iSize iTransfer mappedAddress indices |
-	iSize := numBoids * 3 * 2.
-	iTransfer := gpuDevice newUploadTransferBuffer: iSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: iTransfer cycle: false.
-	indices := FFIArray
-					fromHandle: mappedAddress
-					type: FFIUInt16
-					size: numBoids * 3.
-	1 to: numBoids do: [ :i | 
-		| baseVertex baseIndex |
-		baseVertex := (i - 1) * 3.
-		baseIndex := (i - 1) * 3.
-		indices at: baseIndex + 1 put: baseVertex + 0.
-		indices at: baseIndex + 2 put: baseVertex + 1.
-		indices at: baseIndex + 3 put: baseVertex + 2 ].
-	gpuDevice unmapGPUTransferBuffer: iTransfer.
-
-	gpuDevice acquireGPUCommandBuffer in: [ :commandBuffer | 
-		| copyPass |
-		copyPass := commandBuffer beginGPUCopyPass.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: iTransfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: indexBuffer;
-					offset: 0;
-					size: iSize;
-					yourself)
-			cycle: false.
-		copyPass end.
-		commandBuffer submit ].
-
-	gpuDevice releaseGPUTransferBuffer: iTransfer
 ]
 
 { #category : 'initialization' }
@@ -621,9 +468,34 @@ SDL3GPUBoidsDemo >> uploadInitialData [
 	hues := self generateInitialHues.
 
 	"2. Upload to GPU"
-	self uploadBoids: boids.
-	self uploadHues: hues.
-	self uploadIndices.
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: boidsBufferPing
+			type: SDL3GPUBoidsBoid
+			count: numBoids
+			cycle: false
+			fromPointer: boids getHandle.
+
+		uploader
+			uploadTo: huesBuffer
+			type: FFIFloat32
+			count: numBoids
+			cycle: false
+			fromPointer: hues getHandle.
+
+		uploader
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: numBoids * 3
+			cycle: false
+			fillWith: [ :indices |
+				1 to: numBoids do: [ :i |
+					| baseVertex baseIndex |
+					baseVertex := (i - 1) * 3.
+					baseIndex := (i - 1) * 3.
+					indices at: baseIndex + 1 put: baseVertex + 0.
+					indices at: baseIndex + 2 put: baseVertex + 1.
+					indices at: baseIndex + 3 put: baseVertex + 2 ] ] ].
 
 	boids free.
 	hues free

--- a/src/SDL3-GPUDemos/SDL3GPUClearDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUClearDemo.class.st
@@ -12,25 +12,18 @@ Class {
 { #category : 'rendering' }
 SDL3GPUClearDemo >> doRenderPassesOn: swapchainTexture with: aCommandBuffer [
 
-	| animatedHue renderPass colorTargetInfos |
+	| animatedHue colorTargetInfos |
+
 	animatedHue := (Time millisecondClockValue / 10.0) \\ 360.
 
-	colorTargetInfos := FFIExternalArray externalNewType: SDL_GPUColorTargetInfo size: 1.
-	colorTargetInfos autoRelease.
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		texture: swapchainTexture;
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR;
-		updateClearColorFrom: (Color h: animatedHue s: 1.0 v: 1.0).
+		beClearTexture: swapchainTexture
+		color: (Color h: animatedHue s: 1.0 v: 1.0).
 
-	renderPass :=
-		aCommandBuffer
-			beginGPURenderPassColorTargetInfos: colorTargetInfos
-			depthStencilTargetInfo: nil.
-
-	"HERE: use `SDL3GPURenderPass` to draw"
-
-	renderPass end
+	aCommandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		"HERE: use `SDL3GPURenderPass` to draw"
+	]
 ]
 
 { #category : 'accessing' }

--- a/src/SDL3-GPUDemos/SDL3GPUDemoApp.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUDemoApp.class.st
@@ -1,5 +1,5 @@
 "
-I am an abstract superclass for all SDL3 applications that use the low-level GPU API with a single window. 
+I am an abstract superclass for all SDL3 applications that use the low-level GPU API with a single window.
 
 I manage the GPUDevice lifecycle, coordinate the swapchain texture acquisition, and provide a standardized rendering loop for GPU-driven demos. My subclasses must implement #doRenderPassesOn:with: to define their specific drawing logic.
 
@@ -51,20 +51,9 @@ SDL3GPUDemoApp >> initialWindowFlags [
 SDL3GPUDemoApp >> initialize [
 
 	super initialize.
-	
+
 	"Pre-allocate object to avoid GC pressure in hot path"
 	swapchainTextureHolder := (FFIExternalValueHolder ofType: SDL_GPUTexture) new
-]
-
-{ #category : 'initialization' }
-SDL3GPUDemoApp >> newColorTargetDescriptions: aSize [
-
-	| array |
-	array := FFIExternalArray
-				  externalNewType: SDL_GPUColorTargetDescription
-				  size: aSize.
-	array autoRelease.
-	^ array
 ]
 
 { #category : 'lifecycle' }
@@ -75,7 +64,7 @@ SDL3GPUDemoApp >> open [
 		debugMode: true name: nil.
 
 	shaderFormats := gpuDevice gpuShaderFormatsAsArray.
-	
+
 	super open.
 
 	gpuDevice claimWindow: window
@@ -90,7 +79,7 @@ SDL3GPUDemoApp >> render [
 	"This SDL3 function doesn't block on VSYNC.
 	We do use it to avoid blocking Pharo VM."
 	commandBuffer
-		acquireGPUSwapchainTextureForWindow: window
+		acquireSwapchainTextureForWindow: window
 		into: swapchainTextureHolder
 		width: nil height: nil.
 

--- a/src/SDL3-GPUDemos/SDL3GPUDualKawaseBlurDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUDualKawaseBlurDemo.class.st
@@ -1,7 +1,7 @@
 "
 I demonstrate a Dual Kawase Blur post-processing effect using the SDL3 GPU graphics pipeline.
 
-I render a dynamic scene into an off-screen texture and then apply the blur effect using 
+I render a dynamic scene into an off-screen texture and then apply the blur effect using
 multiple downsampling and upsampling passes with fragment shaders.
 
 Controls:
@@ -24,7 +24,7 @@ Class {
 		'colorTargetInfos',
 		'vertexBufferBindings',
 		'textureSamplerBindings',
-		'indexBinding',
+		'indexBufferBinding',
 		'sceneUniforms',
 		'blurTextures',
 		'downsamplePipeline',
@@ -49,26 +49,26 @@ SDL3GPUDualKawaseBlurDemo >> blurRadius: aFloat [
 { #category : 'lifecycle' }
 SDL3GPUDualKawaseBlurDemo >> close [
 
-	self releaseGPUResources.
+	self release.
 	super close
 ]
 
 { #category : 'rendering' }
 SDL3GPUDualKawaseBlurDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 	"Main rendering entry point called by the app loop"
-	
+
 	| lastTexture |
 
 	self stepQuads.
-	
+
 	"Pass 1: Render the dynamic scene into an off-screen texture"
 	self renderSceneWith: commandBuffer.
-	
+
 	"Pass 2: Apply the Dual Kawase blur chain"
 	lastTexture := self renderBlurWith: commandBuffer.
-	
+
 	"Pass 3: Present the final result by blitting it to the swapchain"
-	self presentTexture: lastTexture on: swapchainTexture with: commandBuffer.
+	self presentTexture: lastTexture on: swapchainTexture with: commandBuffer
 ]
 
 { #category : 'initialization' }
@@ -78,14 +78,14 @@ SDL3GPUDualKawaseBlurDemo >> initialize [
 	blurRadius := 1.0.
 	quads := OrderedCollection new.
 	blurTextures := OrderedCollection new.
-	
-	self initializeFFIContainers.
+
+	self initializeFFIContainers
 ]
 
 { #category : 'initialization' }
 SDL3GPUDualKawaseBlurDemo >> initializeBlurPipelines [
 
-	| vertexShader downShader upShader colorTargets pipelineCreateInfo |
+	| vertexShader downShader upShader colorTargets vertexBindings vertexAttributes |
 	"We use our custom vertex shader that supports uniforms for full-screen quads"
 	vertexShader := SDL3GPUDualKawaseBlurSceneVertexShaderSource
 				newShaderAmong: shaderFormats
@@ -97,39 +97,63 @@ SDL3GPUDualKawaseBlurDemo >> initializeBlurPipelines [
 				newShaderAmong: shaderFormats
 				device: gpuDevice.
 
-	colorTargets := self newColorTargetDescriptions: 1.
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
 	colorTargets first format: SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM.
 
-	pipelineCreateInfo := self
-					 newGraphicsPipelineCreateInfoFor:
-					 vertexShader
-					 colorTargets: colorTargets.
+	vertexBindings := SDL_GPUVertexBufferDescription safeNewArray: 1.
+	vertexBindings first
+		slot: 0;
+		inputRate: SDL_GPU_VERTEXINPUTRATE_VERTEX;
+		pitch: SDL3GPUQuadVertex structureSize.
+
+	vertexAttributes := SDL_GPUVertexAttribute safeNewArray: 2.
+	vertexAttributes first
+		bufferSlot: 0;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
+		location: 0;
+		offset: 0.
+	vertexAttributes second
+		bufferSlot: 0;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
+		location: 1;
+		offset: 12.
 
 	"1. Downsample Pipeline"
-	pipelineCreateInfo fragmentShader: downShader.
-	downsamplePipeline := gpuDevice newGPUGraphicsPipelineCreateinfo:
-					 pipelineCreateInfo.
+	downsamplePipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: downShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
 	"2. Upsample Pipeline"
-	pipelineCreateInfo fragmentShader: upShader.
-	upsamplePipeline := gpuDevice newGPUGraphicsPipelineCreateinfo:
-					pipelineCreateInfo.
+	upsamplePipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: upShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
-	gpuDevice releaseGPUShader: vertexShader.
-	gpuDevice releaseGPUShader: downShader.
-	gpuDevice releaseGPUShader: upShader
+
+	vertexShader release.
+	downShader release.
+	upShader release
 ]
 
 { #category : 'initialization' }
 SDL3GPUDualKawaseBlurDemo >> initializeBlurTextures [
 	"Allocates a chain of textures at progressively halved resolutions"
 	| w h |
-	
+
 	self releaseBlurTextures.
-	
+
 	w := window pixelExtent x.
 	h := window pixelExtent y.
-	
+
 	1 to: numberOfPasses do: [ :i |
 		w := (w / 2) floor max: 1.
 		h := (h / 2) floor max: 1.
@@ -137,7 +161,7 @@ SDL3GPUDualKawaseBlurDemo >> initializeBlurTextures [
 			new2DGPUTextureFormat: SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM
 			usage: SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER
 			width: w
-			height: h).
+			height: h)
 	]
 ]
 
@@ -145,21 +169,14 @@ SDL3GPUDualKawaseBlurDemo >> initializeBlurTextures [
 SDL3GPUDualKawaseBlurDemo >> initializeFFIContainers [
 	"Initialize fixed-size FFI containers used during rendering to avoid allocation in the loop"
 
-	colorTargetInfos := FFIExternalArray
-					externalNewType: SDL_GPUColorTargetInfo
-					size: 1.
-	colorTargetInfos autoRelease.
-	colorTargetInfos first
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR;
-		updateClearColorFrom: (Color r: 0.1 g: 0.1 b: 0.1).
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
+	colorTargetInfos first beClear: (Color r: 0.1 g: 0.1 b: 0.1).
 
 	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
 	textureSamplerBindings := FFIArray
 					  newType: SDL_GPUTextureSamplerBinding
 					  size: 1.
-	indexBinding := SDL_GPUBufferBinding externalNew.
-	indexBinding autoRelease.
+	indexBufferBinding := SDL_GPUBufferBinding offset: 0.
 
 	sceneUniforms := SDL3GPUDualKawaseBlurSceneUniforms new.
 	blurUniforms := SDL3GPUDualKawaseBlurUniforms new
@@ -174,57 +191,71 @@ SDL3GPUDualKawaseBlurDemo >> initializeGPUResources [
 	self initializeGeometry.
 	self initializeScenePipeline.
 	self initializeBlurTextures.
-	self initializeBlurPipelines.
+	self initializeBlurPipelines
 ]
 
 { #category : 'initialization' }
 SDL3GPUDualKawaseBlurDemo >> initializeGeometry [
 	"Initializes common vertex and index buffers for quads"
 
-	| vertexByteSize indexByteSize vertices indices transferBuffer iTransfer commandBuffer |
-	
-	vertexByteSize := SDL3GPUQuadVertex structureSize * 4.
-	indexByteSize := 6 * 2. "6 uint16 indices"
-
-	"1. Allocate GPU buffers"
-	vertexBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX size: vertexByteSize.
-	indexBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX size: indexByteSize.
-
-	"2. Map and fill transfer buffers"
-	transferBuffer := gpuDevice newUploadTransferBuffer: vertexByteSize.
-	vertices := FFIArray fromHandle: (gpuDevice mapGPUTransferBuffer: transferBuffer cycle: true) type: SDL3GPUQuadVertex size: 4.
-	self setupQuadVertices: vertices.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
-
-	iTransfer := gpuDevice newUploadTransferBuffer: indexByteSize.
-	indices := FFIArray fromHandle: (gpuDevice mapGPUTransferBuffer: iTransfer cycle: true) type: FFIUInt16 size: 6.
-	indices at: 1 put: 0; at: 2 put: 1; at: 3 put: 2; at: 4 put: 0; at: 5 put: 2; at: 6 put: 3.
-	gpuDevice unmapGPUTransferBuffer: iTransfer.
-
-	"3. Upload to GPU"
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0)
-		destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: vertexByteSize)
-		cycle: true;
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: iTransfer; offset: 0)
-		destination: (SDL_GPUBufferRegion new buffer: indexBuffer; offset: 0; size: indexByteSize)
-		cycle: true;
-		end.
-	commandBuffer submit.
-
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
-	gpuDevice releaseGPUTransferBuffer: iTransfer
+	self
+		initializeQuadBuffers;
+		setupGeometryBindings
 ]
 
 { #category : 'initialization' }
 SDL3GPUDualKawaseBlurDemo >> initializePharoTexture [
 
-	pharoTexture := gpuDevice newGPUTextureUploadingForm: (self iconNamed: #pharoBig) usage: SDL_GPU_TEXTUREUSAGE_SAMPLER.
+	pharoTexture := gpuDevice newGPUTextureUploadingForm: (self iconNamed: #pharoBig) usage: SDL_GPU_TEXTUREUSAGE_SAMPLER
+]
+
+{ #category : 'initialization' }
+SDL3GPUDualKawaseBlurDemo >> initializeQuadBuffers [
+
+	| vertexByteSize indexByteSize |
+	vertexByteSize := SDL3GPUQuadVertex structureSize * 4.
+	indexByteSize := 6 * 2. "6 uint16 indices"
+
+	"1. Allocate GPU buffers"
+	vertexBuffer := gpuDevice
+		                newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                size: vertexByteSize.
+	indexBuffer := gpuDevice
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+		               size: indexByteSize.
+
+	"2. Upload to GPU"
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: vertexBuffer
+			type: SDL3GPUQuadVertex
+			count: 4
+			cycle: true
+			fillWith: [ :vertices |
+				"Vertices match screen space (Y points down, Top is -0.5, Bottom is 0.5)"
+				vertices first  x: -0.5; y: -0.5; z: 0.0; u: 0.0; v: 0.0. "Top Left"
+				vertices second x:  0.5; y: -0.5; z: 0.0; u: 1.0; v: 0.0. "Top Right"
+				vertices third  x:  0.5; y:  0.5; z: 0.0; u: 1.0; v: 1.0. "Bottom Right"
+				vertices fourth x: -0.5; y:  0.5; z: 0.0; u: 0.0; v: 1.0. "Bottom Left" ].
+
+		uploader
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: 6
+			cycle: true
+			fillWith: [ :indices |
+				indices
+					at: 1 put: 0;
+					at: 2 put: 1;
+					at: 3 put: 2;
+					at: 4 put: 0;
+					at: 5 put: 2;
+					at: 6 put: 3 ] ]
 ]
 
 { #category : 'initialization' }
 SDL3GPUDualKawaseBlurDemo >> initializeQuads [
+
 	| random extent |
 	random := Random new.
 	extent := window pixelExtent.
@@ -236,27 +267,26 @@ SDL3GPUDualKawaseBlurDemo >> initializeQuads [
 			rotation: random next * Float twoPi;
 			rotationSpeed: random next * 0.05 - 0.025;
 			scale: (64 + (random next * 128)) @ (64 + (random next * 128));
-			yourself)
-	]
+			yourself) ]
 ]
 
 { #category : 'initialization' }
 SDL3GPUDualKawaseBlurDemo >> initializeSampler [
 
-	sampler := gpuDevice newGPUSamplerCreateinfo: (SDL_GPUSamplerCreateInfo new
-		minFilter: SDL_GPU_FILTER_LINEAR;
-		magFilter: SDL_GPU_FILTER_LINEAR;
-		mipmapMode: SDL_GPU_FILTER_LINEAR;
-		addressModeU: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-		addressModeV: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-		addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-		yourself).
+	sampler := gpuDevice newSampler: [ :info |
+		info
+			minFilter: SDL_GPU_FILTER_LINEAR;
+			magFilter: SDL_GPU_FILTER_LINEAR;
+			mipmapMode: SDL_GPU_SAMPLERMIPMAPMODE_LINEAR;
+			addressModeU: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+			addressModeV: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+			addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE ]
 ]
 
 { #category : 'initialization' }
 SDL3GPUDualKawaseBlurDemo >> initializeScenePipeline [
 
-	| vertexShader fragmentShader colorTargets pipelineCreateInfo |
+	| vertexShader fragmentShader colorTargets vertexBindings vertexAttributes |
 	vertexShader := SDL3GPUDualKawaseBlurSceneVertexShaderSource
 				newShaderAmong: shaderFormats
 				device: gpuDevice.
@@ -264,111 +294,98 @@ SDL3GPUDualKawaseBlurDemo >> initializeScenePipeline [
 				 newShaderAmong: shaderFormats
 				 device: gpuDevice.
 
-	colorTargets := self newColorTargetDescriptions: 1.
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
 	colorTargets first
 		format: SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM;
-		blendState: self newAlphaBlendState.
+		blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
 
-	pipelineCreateInfo := self
-					 newGraphicsPipelineCreateInfoFor:
-					 vertexShader
-					 colorTargets: colorTargets.
-	pipelineCreateInfo fragmentShader: fragmentShader.
+	vertexBindings := SDL_GPUVertexBufferDescription safeNewArray: 1.
+	vertexBindings first
+		slot: 0;
+		inputRate: SDL_GPU_VERTEXINPUTRATE_VERTEX;
+		pitch: SDL3GPUQuadVertex structureSize.
 
-	scenePipeline := gpuDevice newGPUGraphicsPipelineCreateinfo:
-				pipelineCreateInfo.
+	vertexAttributes := SDL_GPUVertexAttribute safeNewArray: 2.
+	vertexAttributes first
+		bufferSlot: 0;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
+		location: 0;
+		offset: 0.
+	vertexAttributes second
+		bufferSlot: 0;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
+		location: 1;
+		offset: 12.
 
-	gpuDevice releaseGPUShader: vertexShader.
-	gpuDevice releaseGPUShader: fragmentShader
+	scenePipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
+
+	vertexShader release.
+	fragmentShader release
 ]
 
 { #category : 'initialization' }
 SDL3GPUDualKawaseBlurDemo >> initializeSceneTexture [
 
-	sceneTexture ifNotNil: [ gpuDevice releaseGPUTexture: sceneTexture ].
-	sceneTexture := gpuDevice
-				new2DGPUTextureFormat:
-				SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM
-				usage:
-				SDL_GPU_TEXTUREUSAGE_COLOR_TARGET
-				| SDL_GPU_TEXTUREUSAGE_SAMPLER
-				width: window pixelExtent x
-				height: window pixelExtent y
+	sceneTexture ifNotNil: [ sceneTexture release ].
+
+	sceneTexture :=
+		gpuDevice
+			new2DGPUTextureFormat: SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM
+			usage: SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER
+			width: window pixelExtent x
+			height: window pixelExtent y
 ]
 
 { #category : 'initialization' }
-SDL3GPUDualKawaseBlurDemo >> newAlphaBlendState [
-
-	^ SDL_GPUColorTargetBlendState new
-		 enableBlend: true;
-		 srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-		 dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-		 colorBlendOp: SDL_GPU_BLENDOP_ADD;
-		 srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE;
-		 dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ZERO;
-		 alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-		 yourself
-]
-
-{ #category : 'initialization' }
-SDL3GPUDualKawaseBlurDemo >> newGraphicsPipelineCreateInfoFor: vertexShader colorTargets: colorTargets [
-	| pipelineCreateInfo |
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: colorTargets size.
-
-	self setupVertexInputStateFor: pipelineCreateInfo.
-
-	^ pipelineCreateInfo
-]
-
-{ #category : 'accessing' }
 SDL3GPUDualKawaseBlurDemo >> numberOfPasses [
 	^ numberOfPasses
 ]
 
 { #category : 'accessing' }
 SDL3GPUDualKawaseBlurDemo >> numberOfPasses: anInteger [
+
 	numberOfPasses := anInteger max: 0.
 	gpuDevice ifNotNil: [ self initializeBlurTextures ]
 ]
 
 { #category : 'lifecycle' }
 SDL3GPUDualKawaseBlurDemo >> open [
+
 	super open.
 	self initializeQuads.
-	self initializeGPUResources.
+	self initializeGPUResources
 ]
 
 { #category : 'rendering' }
-SDL3GPUDualKawaseBlurDemo >> presentTexture: aTexture on: swapchainTexture with: commandBuffer [
+SDL3GPUDualKawaseBlurDemo >> presentTexture: sourceTexture on: swapchainTexture with: commandBuffer [
 	"Blits the final off-screen result to the window swapchain"
-	| blitInfo windowExtent lastExtent |
-	
+
+	| windowExtent lastExtent |
 	windowExtent := window pixelExtent.
-	
+
 	"Determine the extent of the texture to present"
 	lastExtent := windowExtent.
-	(aTexture ~~ sceneTexture) ifTrue: [ 
+	(sourceTexture ~~ sceneTexture) ifTrue: [
 		"If it's one of the blur textures, it's at half resolution"
-		lastExtent := (windowExtent / 2) floor max: 1@1 
+		lastExtent := (windowExtent / 2) floor max: 1@1
 	].
 
-	blitInfo := SDL3GPUBlitInfo externalNew.
-	blitInfo autoRelease.
-	
-	blitInfo source texture: aTexture; w: lastExtent x; h: lastExtent y.
-	blitInfo destination texture: swapchainTexture; w: windowExtent x; h: windowExtent y.
-		
-	blitInfo loadOp: SDL_GPU_LOADOP_CLEAR.
-	blitInfo clearColor updateFrom: Color black.
-	blitInfo filter: SDL_GPU_FILTER_LINEAR.
-
-	commandBuffer blitGPUTextureInfo: blitInfo.
+	commandBuffer blitFrom: sourceTexture to: swapchainTexture do: [ :blitInfo |
+		blitInfo source
+			w: lastExtent x;
+			h: lastExtent y.
+		blitInfo destination
+			w: windowExtent x;
+			h: windowExtent y.
+		blitInfo loadOp: SDL_GPU_LOADOP_CLEAR.
+		blitInfo updateClearColorFrom: Color black ]
 ]
 
 { #category : 'private' }
@@ -379,9 +396,7 @@ SDL3GPUDualKawaseBlurDemo >> pushBlurUniformsWith: commandBuffer sourceExtent: s
 		texelSizeY: 1.0 / sExtent y;
 		blurRadius: blurRadius.
 	commandBuffer
-		pushGPUFragmentUniformDataSlotIndex: 0
-		data: blurUniforms
-		length: blurUniforms class structureSize.
+		pushFragmentUniform: blurUniforms slot: 0.
 
 	sceneUniforms
 		x: targetExtent x / 2.0;
@@ -392,30 +407,29 @@ SDL3GPUDualKawaseBlurDemo >> pushBlurUniformsWith: commandBuffer sourceExtent: s
 		viewportWidth: targetExtent x asFloat;
 		viewportHeight: targetExtent y asFloat.
 	commandBuffer
-		pushGPUVertexUniformDataSlotIndex: 0
-		data: sceneUniforms
-		length: sceneUniforms class structureSize
+		pushVertexUniform: sceneUniforms slot: 0
+]
+
+{ #category : 'lifecycle' }
+SDL3GPUDualKawaseBlurDemo >> release [
+
+	sceneTexture ifNotNil: [ sceneTexture release ].
+	pharoTexture ifNotNil: [ pharoTexture release ].
+	scenePipeline ifNotNil: [ scenePipeline release ].
+	sampler ifNotNil: [ sampler release ].
+	vertexBuffer ifNotNil: [ vertexBuffer release ].
+	indexBuffer ifNotNil: [ indexBuffer release ].
+
+	self releaseBlurTextures.
+	downsamplePipeline ifNotNil: [ downsamplePipeline release ].
+	upsamplePipeline ifNotNil: [ upsamplePipeline release ]
 ]
 
 { #category : 'lifecycle' }
 SDL3GPUDualKawaseBlurDemo >> releaseBlurTextures [
-	blurTextures do: [ :each | gpuDevice releaseGPUTexture: each ].
-	blurTextures removeAll.
-]
 
-{ #category : 'lifecycle' }
-SDL3GPUDualKawaseBlurDemo >> releaseGPUResources [
-
-	sceneTexture ifNotNil: [ gpuDevice releaseGPUTexture: sceneTexture ].
-	pharoTexture ifNotNil: [ gpuDevice releaseGPUTexture: pharoTexture ].
-	scenePipeline ifNotNil: [ gpuDevice releaseGPUGraphicsPipeline: scenePipeline ].
-	sampler ifNotNil: [ gpuDevice releaseGPUSampler: sampler ].
-	vertexBuffer ifNotNil: [ gpuDevice releaseGPUBuffer: vertexBuffer ].
-	indexBuffer ifNotNil: [ gpuDevice releaseGPUBuffer: indexBuffer ].
-	
-	self releaseBlurTextures.
-	downsamplePipeline ifNotNil: [ gpuDevice releaseGPUGraphicsPipeline: downsamplePipeline ].
-	upsamplePipeline ifNotNil: [ gpuDevice releaseGPUGraphicsPipeline: upsamplePipeline ].
+	blurTextures do: [ :each | each release ].
+	blurTextures removeAll
 ]
 
 { #category : 'rendering' }
@@ -429,7 +443,7 @@ SDL3GPUDualKawaseBlurDemo >> renderBlurWith: commandBuffer [
 	currentExtent := window pixelExtent.
 
 	"1. Downsample chain"
-	blurTextures do: [ :target | 
+	blurTextures do: [ :target |
 		currentExtent := self
 					renderKawasePassWith: commandBuffer
 					pipeline: downsamplePipeline
@@ -439,7 +453,7 @@ SDL3GPUDualKawaseBlurDemo >> renderBlurWith: commandBuffer [
 		currentSource := target ].
 
 	"2. Upsample chain"
-	blurTextures size - 1 to: 1 by: -1 do: [ :i | 
+	blurTextures size - 1 to: 1 by: -1 do: [ :i |
 		| target |
 		target := blurTextures at: i.
 		currentExtent := self
@@ -457,48 +471,42 @@ SDL3GPUDualKawaseBlurDemo >> renderBlurWith: commandBuffer [
 SDL3GPUDualKawaseBlurDemo >> renderKawasePassWith: commandBuffer pipeline: pipeline source: source sourceExtent: sExtent target: target [
 	"Executes a single downsample or upsample pass"
 
-	| renderPass targetExtent |
-	targetExtent := self
-				targetExtentFor: target
-				sourceExtent: sExtent
-				pipeline: pipeline.
+	| targetExtent |
+	targetExtent :=
+		self
+			targetExtentFor: target
+			sourceExtent: sExtent
+			pipeline: pipeline.
 
 	colorTargetInfos first texture: target.
-	renderPass := commandBuffer
-				 beginGPURenderPassColorTargetInfos: colorTargetInfos
-				 depthStencilTargetInfo: nil.
-	renderPass bindGPUGraphicsPipeline: pipeline.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		vertexBufferBindings first
+			buffer: vertexBuffer;
+			offset: 0.
+		indexBufferBinding
+			buffer: indexBuffer;
+			offset: 0.
+		textureSamplerBindings first
+			texture: source;
+			sampler: sampler.
 
-	vertexBufferBindings first
-		buffer: vertexBuffer;
-		offset: 0.
-	renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings.
-	indexBinding
-		buffer: indexBuffer;
-		offset: 0.
-	renderPass
-		bindGPUIndexBufferBinding: indexBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
+		renderPass
+			pipeline: pipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			indexBuffer16Bit: indexBufferBinding;
+			fragmentSamplers: textureSamplerBindings slot: 0.
 
-	textureSamplerBindings first
-		texture: source;
-		sampler: sampler.
-	renderPass
-		bindGPUFragmentSamplersFirstSlot: 0
-		textureSamplerBindings: textureSamplerBindings.
+		self
+			pushBlurUniformsWith: commandBuffer
+			sourceExtent: sExtent
+			targetExtent: targetExtent.
 
-	self
-		pushBlurUniformsWith: commandBuffer
-		sourceExtent: sExtent
-		targetExtent: targetExtent.
-
-	renderPass
-		drawGPUIndexedPrimitivesNumIndices: 6
-		numInstances: 1
-		firstIndex: 0
-		vertexOffset: 0
-		firstInstance: 0.
-	renderPass end.
+		renderPass
+			drawIndexedPrimitives: 6
+			instances: 1
+			firstIndex: 0
+			vertexOffset: 0
+			firstInstance: 0 ].
 
 	^ targetExtent
 ]
@@ -513,12 +521,10 @@ SDL3GPUDualKawaseBlurDemo >> renderQuad: quad with: commandBuffer on: renderPass
 		scaleY: quad scale y;
 		rotation: quad rotation.
 	commandBuffer
-		pushGPUVertexUniformDataSlotIndex: 0
-		data: sceneUniforms
-		length: sceneUniforms class structureSize.
+		pushVertexUniform: sceneUniforms slot: 0.
 	renderPass
-		drawGPUIndexedPrimitivesNumIndices: 6
-		numInstances: 1
+		drawIndexedPrimitives: 6
+		instances: 1
 		firstIndex: 0
 		vertexOffset: 0
 		firstInstance: 0
@@ -528,85 +534,56 @@ SDL3GPUDualKawaseBlurDemo >> renderQuad: quad with: commandBuffer on: renderPass
 SDL3GPUDualKawaseBlurDemo >> renderSceneWith: commandBuffer [
 	"Renders the initial bouncing logos scene"
 
-	| renderPass extent |
+	| extent |
 	extent := window pixelExtent.
 	colorTargetInfos first texture: sceneTexture.
 
-	renderPass := commandBuffer
-				 beginGPURenderPassColorTargetInfos: colorTargetInfos
-				 depthStencilTargetInfo: nil.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		renderPass pipeline: scenePipeline.
 
-	renderPass bindGPUGraphicsPipeline: scenePipeline.
+		vertexBufferBindings first
+			buffer: vertexBuffer;
+			offset: 0.
+		indexBufferBinding
+			buffer: indexBuffer;
+			offset: 0.
+		renderPass
+			vertexBuffers: vertexBufferBindings slot: 0;
+			indexBuffer16Bit: indexBufferBinding.
+
+		textureSamplerBindings first
+			texture: pharoTexture;
+			sampler: sampler.
+		renderPass fragmentSamplers: textureSamplerBindings slot: 0.
+
+		sceneUniforms
+			viewportWidth: extent x asFloat;
+			viewportHeight: extent y asFloat.
+
+		quads do: [ :quad |
+			self
+				renderQuad: quad
+				with: commandBuffer
+				on: renderPass ] ]
+]
+
+{ #category : 'initialization' }
+SDL3GPUDualKawaseBlurDemo >> setupGeometryBindings [
 
 	vertexBufferBindings first
 		buffer: vertexBuffer;
 		offset: 0.
-	renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings.
-
-	indexBinding
+	indexBufferBinding
 		buffer: indexBuffer;
-		offset: 0.
-	renderPass
-		bindGPUIndexBufferBinding: indexBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-
-	textureSamplerBindings first
-		texture: pharoTexture;
-		sampler: sampler.
-	renderPass
-		bindGPUFragmentSamplersFirstSlot: 0
-		textureSamplerBindings: textureSamplerBindings.
-
-	sceneUniforms
-		viewportWidth: extent x asFloat;
-		viewportHeight: extent y asFloat.
-
-	quads do: [ :quad | 
-		self
-			renderQuad: quad
-			with: commandBuffer
-			on: renderPass ].
-
-	renderPass end
+		offset: 0
 ]
 
 { #category : 'initialization' }
-SDL3GPUDualKawaseBlurDemo >> setupQuadVertices: vertices [
-	"Corrected Vertices to match screen space (Y points down, Top is -0.5, Bottom is 0.5)"
-	(vertices at: 1) x: -0.5; y: -0.5; z: 0.0; u: 0.0; v: 0.0. "Top Left"
-	(vertices at: 2) x: 0.5; y: -0.5; z: 0.0; u: 1.0; v: 0.0.  "Top Right"
-	(vertices at: 3) x: 0.5; y: 0.5; z: 0.0; u: 1.0; v: 1.0.   "Bottom Right"
-	(vertices at: 4) x: -0.5; y: 0.5; z: 0.0; u: 0.0; v: 1.0.  "Bottom Left"
-]
-
-{ #category : 'initialization' }
-SDL3GPUDualKawaseBlurDemo >> setupVertexInputStateFor: aPipelineCreateInfo [
-	| vertexBindings vertexAttributes |
-	
-	vertexBindings := FFIExternalArray externalNewType: SDL_GPUVertexBufferDescription size: 1.
-	vertexBindings autoRelease.
-	vertexBindings first
-		slot: 0;
-		inputRate: SDL_GPU_VERTEXINPUTRATE_VERTEX;
-		pitch: SDL3GPUQuadVertex structureSize.
-
-	vertexAttributes := FFIExternalArray externalNewType: SDL_GPUVertexAttribute size: 2.
-	vertexAttributes autoRelease.
-	(vertexAttributes at: 1) bufferSlot: 0; format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3; location: 0; offset: 0.
-	(vertexAttributes at: 2) bufferSlot: 0; format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2; location: 1; offset: 12.
-
-	aPipelineCreateInfo vertexInputState
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: 1;
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: 2.
-]
-
-{ #category : 'stepping' }
 SDL3GPUDualKawaseBlurDemo >> stepQuads [
+
 	| extent |
 	extent := window pixelExtent.
-	quads do: [ :each | each stepIn: extent ].
+	quads do: [ :each | each stepIn: extent ]
 ]
 
 { #category : 'private' }
@@ -614,14 +591,14 @@ SDL3GPUDualKawaseBlurDemo >> targetExtentFor: target sourceExtent: sExtent pipel
 
 	^ pipeline == downsamplePipeline
 		 ifTrue: [ (sExtent / 2) floor max: 1 @ 1 ]
-		 ifFalse: [ 
+		 ifFalse: [
 		 (sExtent * 2) min: (window pixelExtent / 2) floor max: 1 @ 1 ]
 ]
 
 { #category : 'accessing' }
 SDL3GPUDualKawaseBlurDemo >> updatedTitle [
 
-	^ '{1} - Passes: {2}, Radius: {3}' format: { 
+	^ '{1} - Passes: {2}, Radius: {3}' format: {
 		super updatedTitle.
 		numberOfPasses.
 		blurRadius printShowingDecimalPlaces: 1
@@ -630,23 +607,25 @@ SDL3GPUDualKawaseBlurDemo >> updatedTitle [
 
 { #category : 'hooks' }
 SDL3GPUDualKawaseBlurDemo >> visitKeyboardDownEvent: aKeyboardDownEvent [
+
 	| key |
 	super visitKeyboardDownEvent: aKeyboardDownEvent.
 	key := aKeyboardDownEvent key.
-	
+
 	key = SDLK_UP asInteger ifTrue: [ blurRadius := blurRadius + 0.1 ].
 	key = SDLK_DOWN asInteger ifTrue: [ blurRadius := (blurRadius - 0.1) max: 0.0 ].
-	
+
 	key = SDLK_RIGHT asInteger ifTrue: [ self numberOfPasses: (numberOfPasses + 1) ].
 	key = SDLK_LEFT asInteger ifTrue: [ self numberOfPasses: ((numberOfPasses - 1) max: 0) ].
-	
-	self updateTitle.
+
+	self updateTitle
 ]
 
 { #category : 'visiting - concrete' }
 SDL3GPUDualKawaseBlurDemo >> visitWindowPixelSizeChangedEvent: aWindowPixelSizeChangedEvent [
+
 	super visitWindowPixelSizeChangedEvent: aWindowPixelSizeChangedEvent.
-	
+
 	self initializeSceneTexture.
-	self initializeBlurTextures.
+	self initializeBlurTextures
 ]

--- a/src/SDL3-GPUDemos/SDL3GPUDualKawaseBlurQuad.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUDualKawaseBlurQuad.class.st
@@ -61,13 +61,13 @@ SDL3GPUDualKawaseBlurQuad >> stepIn: anExtent [
 
 	position := position + velocity.
 	rotation := rotation + rotationSpeed.
-	
+
 	"Bounce"
-	(position x < 0 or: [ position x > anExtent x ]) ifTrue: [ 
+	(position x < 0 or: [ position x > anExtent x ]) ifTrue: [
 		velocity := (velocity x negated) @ velocity y.
 		position := (position x min: anExtent x max: 0) @ position y ].
 
-	(position y < 0 or: [ position y > anExtent y ]) ifTrue: [ 
+	(position y < 0 or: [ position y > anExtent y ]) ifTrue: [
 		velocity := velocity x @ (velocity y negated).
 		position := position x @ (position y min: anExtent y max: 0) ].
 ]

--- a/src/SDL3-GPUDemos/SDL3GPUDualKawaseBlurSceneVertexShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUDualKawaseBlurSceneVertexShaderSource.class.st
@@ -54,22 +54,22 @@ struct VertexOutput {
 
 VertexOutput main(VertexInput input) {
  VertexOutput output;
- 
+
  float cosR = cos(rotation);
  float sinR = sin(rotation);
- 
+
  float2 pos = input.position * float2(scaleX, scaleY);
  float2 rotatedPos;
  rotatedPos.x = pos.x * cosR - pos.y * sinR;
  rotatedPos.y = pos.x * sinR + pos.y * cosR;
- 
+
  rotatedPos += float2(x, y);
- 
+
  output.position.x = (rotatedPos.x / viewportWidth) * 2.0 - 1.0;
  output.position.y = (rotatedPos.y / viewportHeight) * -2.0 + 1.0;
  output.position.z = 0.0;
  output.position.w = 1.0;
- 
+
  output.uv = input.uv;
  return output;
 }'

--- a/src/SDL3-GPUDemos/SDL3GPUDualKawaseDownsampleFragmentShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUDualKawaseDownsampleFragmentShaderSource.class.st
@@ -44,13 +44,13 @@ cbuffer BlurUniforms : register(b0, space3) {
 
 float4 main(float2 uv : TEXCOORD0) : SV_Target {
  float2 offset = texelSize * (blurRadius + 0.5);
- 
+
  float4 sum = tex.Sample(sam, uv) * 4.0;
  sum += tex.Sample(sam, uv - offset);
  sum += tex.Sample(sam, uv + offset);
  sum += tex.Sample(sam, uv + float2(offset.x, -offset.y));
  sum += tex.Sample(sam, uv + float2(-offset.x, offset.y));
- 
+
  return sum / 8.0;
 }'
 ]

--- a/src/SDL3-GPUDemos/SDL3GPUDualKawaseUpsampleFragmentShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUDualKawaseUpsampleFragmentShaderSource.class.st
@@ -44,7 +44,7 @@ cbuffer BlurUniforms : register(b0, space3) {
 
 float4 main(float2 uv : TEXCOORD0) : SV_Target {
  float2 offset = texelSize * blurRadius;
- 
+
  float4 sum = tex.Sample(sam, uv + float2(-offset.x * 2.0, 0.0));
  sum += tex.Sample(sam, uv + float2(-offset.x, offset.y)) * 2.0;
  sum += tex.Sample(sam, uv + float2(0.0, offset.y * 2.0));
@@ -53,7 +53,7 @@ float4 main(float2 uv : TEXCOORD0) : SV_Target {
  sum += tex.Sample(sam, uv + float2(offset.x, -offset.y)) * 2.0;
  sum += tex.Sample(sam, uv + float2(0.0, -offset.y * 2.0));
  sum += tex.Sample(sam, uv + float2(-offset.x, -offset.y)) * 2.0;
- 
+
  return sum / 12.0;
 }'
 ]

--- a/src/SDL3-GPUDemos/SDL3GPUGaussianBlurComputeDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUGaussianBlurComputeDemo.class.st
@@ -16,11 +16,7 @@ Class {
 		'indexBuffer',
 		'indexBinding',
 		'writeTexture',
-		'blurRadius',
-		'blurSpread',
-		'brightness',
 		'bufferIndex',
-		'vertexTransferBuffer',
 		'lastExtent',
 		'computePipeline',
 		'intermediateTexture',
@@ -37,77 +33,72 @@ Class {
 { #category : 'lifecycle' }
 SDL3GPUGaussianBlurComputeDemo >> close [
 
-	gpuPipeline ifNotNil: [ 
-		gpuDevice releaseGPUGraphicsPipeline: gpuPipeline.
+	gpuPipeline ifNotNil: [
+		gpuPipeline release.
 		gpuPipeline := nil ].
 
-	computePipeline ifNotNil: [ 
-		gpuDevice releaseGPUComputePipeline: computePipeline.
+	computePipeline ifNotNil: [
+		computePipeline release.
 		computePipeline := nil ].
 
-	vertexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: vertexBuffer.
+	vertexBuffer ifNotNil: [
+		vertexBuffer release.
 		vertexBuffer := nil ].
 
-	vertexTransferBuffer ifNotNil: [
-		gpuDevice releaseGPUTransferBuffer: vertexTransferBuffer.
-		vertexTransferBuffer := nil ].
-
-	indexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: indexBuffer.
+	indexBuffer ifNotNil: [
+		indexBuffer release.
 		indexBuffer := nil ].
 
-	sampler ifNotNil: [ 
-		gpuDevice releaseGPUSampler: sampler.
+	sampler ifNotNil: [
+		sampler release.
 		sampler := nil ].
 
-	texture ifNotNil: [ 
-		gpuDevice releaseGPUTexture: texture.
+	texture ifNotNil: [
+		texture release.
 		texture := nil ].
 
-	intermediateTexture ifNotNil: [ 
-		gpuDevice releaseGPUTexture: intermediateTexture.
+	intermediateTexture ifNotNil: [
+		intermediateTexture release.
 		intermediateTexture := nil ].
 
-	writeTexture ifNotNil: [ 
-		gpuDevice releaseGPUTexture: writeTexture.
+	writeTexture ifNotNil: [
+		writeTexture release.
 		writeTexture := nil ].
 
 	super close
 ]
 
 { #category : 'rendering' }
-SDL3GPUGaussianBlurComputeDemo >> doRenderPassesOn: swapchainTexture with: aSDL3GPUCommandBuffer [
+SDL3GPUGaussianBlurComputeDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 
+	"Pass 1: Horizontal Blur (Force brightness to 1.0)"
 	self
-		executeBlurPassWith: aSDL3GPUCommandBuffer
+		executeBlurPassWith: commandBuffer
 		direction: 0
 		inputTexture: texture
 		outputTexture: intermediateTexture
 		brightness: 1.0.
-		
+
+	"Pass 2: Vertical Blur (Use current state brightness)"
 	self
-		executeBlurPassWith: aSDL3GPUCommandBuffer
+		executeBlurPassWith: commandBuffer
 		direction: 1
 		inputTexture: intermediateTexture
 		outputTexture: writeTexture
-		brightness: brightness.
-		
-	self executeFinalRenderPassOn: swapchainTexture with: aSDL3GPUCommandBuffer
+		brightness: uniforms brightness.
+
+	self executeFinalRenderPassOn: swapchainTexture with: commandBuffer
 ]
 
 { #category : 'private' }
-SDL3GPUGaussianBlurComputeDemo >> executeBlurPassWith: aSDL3GPUCommandBuffer direction: aDirection inputTexture: inputTexture outputTexture: outputTexture brightness: aBrightness [
+SDL3GPUGaussianBlurComputeDemo >> executeBlurPassWith: commandBuffer direction: direction inputTexture: inputTexture outputTexture: outputTexture brightness: passBrightness [
 
 	uniforms
-		blurRadius: blurRadius;
-		blurSpread: blurSpread;
-		direction: aDirection;
-		brightness: aBrightness.
-	aSDL3GPUCommandBuffer
-		pushGPUComputeUniformDataSlotIndex: 0
-		data: uniforms
-		length: SDL3GPUBlurUniforms structureSize.
+		direction: direction;
+		brightness: passBrightness.
+		
+	commandBuffer
+		pushComputeUniform: uniforms slot: 0.
 
 	storageTextureArray at: 1 put: outputTexture.
 
@@ -119,75 +110,48 @@ SDL3GPUGaussianBlurComputeDemo >> executeBlurPassWith: aSDL3GPUCommandBuffer dir
 		texture: inputTexture;
 		sampler: sampler.
 
-	(aSDL3GPUCommandBuffer
-		beginGPUComputePassStorageTextureBindings: blurStorageBindings
-		storageBufferBindings: #())
-		bindGPUComputePipeline: computePipeline;
-		bindGPUComputeStorageTexturesFirstSlot: 0
-		storageTextures: storageTextureArray;
-		bindGPUComputeSamplersFirstSlot: 0
-		textureSamplerBindings: blurSamplerBindings;
-		dispatchWorkgroupCountX: lastExtent x + 7 // 8
-		y: lastExtent y + 7 // 8
-		z: 1;
-		end
+	commandBuffer computePassTextures: blurStorageBindings computeStorageBuffers: #() do: [ :computePass |
+		computePass
+			pipeline: computePipeline;
+			computeStorageTextures: storageTextureArray slot: 0;
+			computeSamplers: blurSamplerBindings slot: 0;
+			dispatchX: lastExtent x + 7 // 8
+			y: lastExtent y + 7 // 8
+			z: 1 ]
 ]
 
 { #category : 'private' }
-SDL3GPUGaussianBlurComputeDemo >> executeFinalRenderPassOn: swapchainTexture with: aSDL3GPUCommandBuffer [
+SDL3GPUGaussianBlurComputeDemo >> executeFinalRenderPassOn: swapchainTexture with: commandBuffer [
 
-	| renderPass |
 	colorTargetInfos first texture: swapchainTexture.
-	renderPass := aSDL3GPUCommandBuffer
-				 beginGPURenderPassColorTargetInfos: colorTargetInfos
-				 depthStencilTargetInfo: nil.
-
-	renderPass bindGPUGraphicsPipeline: gpuPipeline.
-
-	vertexBufferBindings first buffer: vertexBuffer.
-	renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings.
-
-	indexBinding buffer: indexBuffer.
-	renderPass
-		bindGPUIndexBufferBinding: indexBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-
 	textureSamplerBindings first
 		texture: writeTexture;
 		sampler: sampler.
-	renderPass
-		bindGPUFragmentSamplersFirstSlot: 0
-		textureSamplerBindings: textureSamplerBindings.
 
-	renderPass
-		drawGPUIndexedPrimitivesNumIndices: 6
-		numInstances: 1
-		firstIndex: 0
-		vertexOffset: 0
-		firstInstance: 0.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		vertexBufferBindings first buffer: vertexBuffer.
+		indexBinding buffer: indexBuffer.
 
-	renderPass end
-]
-
-{ #category : 'private' }
-SDL3GPUGaussianBlurComputeDemo >> fillIndexTransferBuffer: iTransfer [
-
-	| mappedAddress indices |
-	mappedAddress := gpuDevice mapGPUTransferBuffer: iTransfer cycle: false.
-	indices := FFIArray fromHandle: mappedAddress type: FFIUInt16 size: 6.
-	#( 1 2 3 1 3 4 ) doWithIndex: [ :val :idx | 
-		indices at: idx put: val - 1 ].
-	gpuDevice unmapGPUTransferBuffer: iTransfer
+		renderPass
+			pipeline: gpuPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			indexBuffer16Bit: indexBinding;
+			fragmentSamplers: textureSamplerBindings slot: 0;
+			drawIndexedPrimitives: 6
+			instances: 1
+			firstIndex: 0
+			vertexOffset: 0
+			firstInstance: 0 ]
 ]
 
 { #category : 'initialization' }
 SDL3GPUGaussianBlurComputeDemo >> handleResize [
 	"Recreate textures and pipelines based on the new window extent"
 
-	gpuDevice releaseGPUTexture: texture.
-	gpuDevice releaseGPUTexture: intermediateTexture.
-	gpuDevice releaseGPUTexture: writeTexture.
-	
+	texture release.
+	intermediateTexture release.
+	writeTexture release.
+
 	self initializeTexture.
 	self initializeComputeResources
 ]
@@ -197,9 +161,6 @@ SDL3GPUGaussianBlurComputeDemo >> initialize [
 
 	super initialize.
 
-	blurRadius := 0.0.
-	blurSpread := 1.0.
-	brightness := 1.0.
 	bufferIndex := 1.
 
 	colorTargetInfos := FFIArray newType: SDL_GPUColorTargetInfo size: 1.
@@ -212,23 +173,19 @@ SDL3GPUGaussianBlurComputeDemo >> initialize [
 
 	textureSamplerBindings := FFIArray newType: SDL_GPUTextureSamplerBinding size: 1.
 
-	indexBinding := SDL_GPUBufferBinding externalNew.
-	indexBinding autoRelease.
-	indexBinding offset: 0.
+	indexBinding := SDL_GPUBufferBinding offset: 0.
 
-	blurStorageBindings := FFIExternalArray
-					  externalNewType:
-					  SDL_GPUStorageTextureReadWriteBinding
-					  size: 1.
-	blurStorageBindings autoRelease.
+	blurStorageBindings := SDL3GPUStorageTextureReadWriteBinding safeNewArray: 1.
 
-	blurSamplerBindings := FFIExternalArray
-					  externalNewType: SDL_GPUTextureSamplerBinding
-					  size: 1.
-	blurSamplerBindings autoRelease.
+	blurSamplerBindings := SDL3GPUTextureSamplerBinding safeNewArray: 1.
 
 	uniforms := SDL3GPUBlurUniforms new.
-	storageTextureArray := FFIArray newType: SDL_GPUTexture size: 1.
+	uniforms
+		blurRadius: 0.0;
+		blurSpread: 1.0;
+		brightness: 1.0.
+		
+	storageTextureArray := FFIArray newType: SDL_GPUTexture size: 1
 ]
 
 { #category : 'initialization' }
@@ -244,7 +201,7 @@ SDL3GPUGaussianBlurComputeDemo >> initializeComputeResources [
 			usage: SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE
 			width: lastExtent x
 			height: lastExtent y.
-			
+
 	intermediateTexture :=
 		gpuDevice
 			new2DGPUTextureFormat: SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM
@@ -257,29 +214,63 @@ SDL3GPUGaussianBlurComputeDemo >> initializeComputeResources [
 SDL3GPUGaussianBlurComputeDemo >> initializeGeometry [
 	"Initialize a single full-screen quad"
 
-	| iTransfer |
-	vertexTransferBuffer := gpuDevice newUploadTransferBuffer:
-					SDL3GPUQuadVertex structureSize * 4.
 	vertexBuffer := gpuDevice
-				newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
-				size: SDL3GPUQuadVertex structureSize * 4.
-
-	iTransfer := gpuDevice newUploadTransferBuffer: 2 * 6. "16-bit indices"
-	self fillIndexTransferBuffer: iTransfer.
+		                newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                size: SDL3GPUQuadVertex structureSize * 4.
 
 	indexBuffer := gpuDevice
-				  newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
-				  size: 2 * 6.
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+		               size: 2 * 6.
 
-	self uploadStaticGeometryWithIndexTransfer: iTransfer.
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: vertexBuffer
+			type: SDL3GPUQuadVertex
+			count: 4
+			cycle: false
+			fillWith: [ :vertices |
+				vertices first
+					x: -1.0;
+					y: 1.0;
+					z: 0.0;
+					u: 0.0;
+					v: 0.0.
+				vertices second
+					x: 1.0;
+					y: 1.0;
+					z: 0.0;
+					u: 1.0;
+					v: 0.0.
+				vertices third
+					x: 1.0;
+					y: -1.0;
+					z: 0.0;
+					u: 1.0;
+					v: 1.0.
+				vertices fourth
+					x: -1.0;
+					y: -1.0;
+					z: 0.0;
+					u: 0.0;
+					v: 1.0 ].
 
-	gpuDevice releaseGPUTransferBuffer: iTransfer
+		uploader
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: 6
+			cycle: false
+			fillWith: [ :indices |
+				#( 0 1 2 0 2 3 ) doWithIndex: [ :val :idx |
+					indices at: idx put: val ] ] ]
 ]
 
 { #category : 'initialization' }
 SDL3GPUGaussianBlurComputeDemo >> initializePipeline [
 
-	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets pipelineCreateInfo |
+	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets |
+
+	shaderFormats := gpuDevice gpuShaderFormatsAsArray.
+
 	vertexShader := SDL3GPUQuadVertexShaderSource
 				newShaderAmong: shaderFormats
 				device: gpuDevice.
@@ -291,43 +282,32 @@ SDL3GPUGaussianBlurComputeDemo >> initializePipeline [
 	vertexAttributes := self newVertexAttributeDescriptions.
 	colorTargets := self newColorTargetDescriptions.
 
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader;
-		fragmentShader: fragmentShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: colorTargets size.
-	pipelineCreateInfo vertexInputState
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: vertexBindings size;
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: vertexAttributes size.
+	gpuPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
-	gpuPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
-
-	gpuDevice releaseGPUShader: vertexShader.
-	gpuDevice releaseGPUShader: fragmentShader.
-	vertexBindings free.
-	vertexAttributes free.
-	colorTargets free
+	vertexShader release.
+	fragmentShader release
 ]
 
 { #category : 'initialization' }
 SDL3GPUGaussianBlurComputeDemo >> initializeSampler [
 
-	sampler := gpuDevice newGPUSamplerCreateinfo: (SDL3GPUSamplerCreateInfo new
-		minFilter: SDL_GPU_FILTER_LINEAR;
+	sampler := gpuDevice newSampler: [ :info |
+		info minFilter: SDL_GPU_FILTER_LINEAR;
 		magFilter: SDL_GPU_FILTER_LINEAR;
 		mipmapMode: SDL_GPU_FILTER_LINEAR;
 		addressModeU: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
 		addressModeV: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
 		addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-		yourself).
+		yourself ].
 
-		textureSamplerBindings first sampler: sampler
-
+	textureSamplerBindings first sampler: sampler
 ]
 
 { #category : 'initialization' }
@@ -337,7 +317,7 @@ SDL3GPUGaussianBlurComputeDemo >> initializeTexture [
 	lastExtent := window pixelExtent.
 
 	"Take a snapshot of a browser to be used as background"
-	browserMorph :=(Object >> #at:put:) browse owner.
+	browserMorph := (Object >> #at:put:) browse owner.
 	form := browserMorph extent: lastExtent; asForm.
 	browserMorph delete.
 
@@ -351,7 +331,7 @@ SDL3GPUGaussianBlurComputeDemo >> initializeTexture [
 SDL3GPUGaussianBlurComputeDemo >> newColorTargetDescriptions [
 
 	| colorTargets |
-	colorTargets := self newColorTargetDescriptions: 1.
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
 	colorTargets first
 		format: (gpuDevice getGPUSwapchainTextureFormatIntoWindow: window);
 		blendState: SDL_GPUColorTargetBlendState new.
@@ -411,81 +391,9 @@ SDL3GPUGaussianBlurComputeDemo >> updatedTitle [
 	^ super updatedTitle,
 		(' - Radius: {1} (UP/DOWN) - Spread: {2} (LEFT/RIGHT) - Brightness: {3} (W/S)'
 			format: {
-				blurRadius printShowingDecimalPlaces: 1.
-				blurSpread printShowingDecimalPlaces: 1.
-				brightness printShowingDecimalPlaces: 1 })
-]
-
-{ #category : 'private' }
-SDL3GPUGaussianBlurComputeDemo >> uploadStaticGeometryWithIndexTransfer: iTransfer [
-
-	| mappedAddress |
-	gpuDevice acquireGPUCommandBuffer in: [ :commandBuffer | 
-		| copyPass |
-		mappedAddress := gpuDevice
-					mapGPUTransferBuffer: vertexTransferBuffer
-					cycle: false.
-
-		(FFIArray fromHandle: mappedAddress type: SDL3GPUQuadVertex size: 4)
-			at: 1
-			put: (SDL3GPUQuadVertex new
-					x: -1.0;
-					y: 1.0;
-					z: 0.0;
-					u: 0.0;
-					v: 0.0;
-					yourself);
-			at: 2
-			put: (SDL3GPUQuadVertex new
-					x: 1.0;
-					y: 1.0;
-					z: 0.0;
-					u: 1.0;
-					v: 0.0;
-					yourself);
-			at: 3
-			put: (SDL3GPUQuadVertex new
-					x: 1.0;
-					y: -1.0;
-					z: 0.0;
-					u: 1.0;
-					v: 1.0;
-					yourself);
-			at: 4
-			put: (SDL3GPUQuadVertex new
-					x: -1.0;
-					y: -1.0;
-					z: 0.0;
-					u: 0.0;
-					v: 1.0;
-					yourself).
-		gpuDevice unmapGPUTransferBuffer: vertexTransferBuffer.
-
-		copyPass := commandBuffer beginGPUCopyPass.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: vertexTransferBuffer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: vertexBuffer;
-					offset: 0;
-					size: SDL3GPUQuadVertex structureSize * 4;
-					yourself)
-			cycle: false.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: iTransfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: indexBuffer;
-					offset: 0;
-					size: 2 * 6;
-					yourself)
-			cycle: false.
-		copyPass end.
-		commandBuffer submit ]
+				uniforms blurRadius printShowingDecimalPlaces: 1.
+				uniforms blurSpread printShowingDecimalPlaces: 1.
+				uniforms brightness printShowingDecimalPlaces: 1 })
 ]
 
 { #category : 'hooks' }
@@ -494,18 +402,18 @@ SDL3GPUGaussianBlurComputeDemo >> visitKeyboardDownEvent: aKeyboardDownEvent [
 	super visitKeyboardDownEvent: aKeyboardDownEvent.
 
 	aKeyboardDownEvent key = SDLK_UP asInteger ifTrue: [
-		blurRadius := (blurRadius + 0.5) min: 10.0 ].
+		uniforms blurRadius: (uniforms blurRadius + 0.5 min: 10.0) ].
 	aKeyboardDownEvent key = SDLK_DOWN asInteger ifTrue: [
-		blurRadius := (blurRadius - 0.5) max: 0.0 ].
+		uniforms blurRadius: (uniforms blurRadius - 0.5 max: 0.0) ].
 	aKeyboardDownEvent key = SDLK_LEFT asInteger ifTrue: [
-		blurSpread := (blurSpread - 0.5) max: 1.0 ].
+		uniforms blurSpread: (uniforms blurSpread - 0.5 max: 1.0) ].
 	aKeyboardDownEvent key = SDLK_RIGHT asInteger ifTrue: [
-		blurSpread := (blurSpread + 0.5) min: 4.0 ].
+		uniforms blurSpread: (uniforms blurSpread + 0.5 min: 4.0) ].
 	aKeyboardDownEvent key = SDLK_W asInteger ifTrue: [
-		brightness := (brightness + 0.1) min: 2.0 ].
+		uniforms brightness: (uniforms brightness + 0.1 min: 2.0) ].
 	aKeyboardDownEvent key = SDLK_S asInteger ifTrue: [
-		brightness := (brightness - 0.1) max: 0.0 ].
-	
+		uniforms brightness: (uniforms brightness - 0.1 max: 0.0) ].
+
 	self updateTitle
 ]
 

--- a/src/SDL3-GPUDemos/SDL3GPUGaussianBlurShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUGaussianBlurShaderSource.class.st
@@ -62,9 +62,9 @@ void main(uint3 id : SV_DispatchThreadID)
 
    float4 color = float4(0, 0, 0, 0);
    float totalWeight = 0.0;
-   
+
    int radius = (int)ceil(blurRadius * 3.0);
-   
+
    for (int i = -radius; i <= radius; i++) {
        float2 offset;
        if (direction == 0) {
@@ -72,12 +72,12 @@ void main(uint3 id : SV_DispatchThreadID)
        } else {
            offset = float2(0, i) * texelSize * blurSpread;
        }
-       
+
        float weight = exp(-(float(i * i)) / (2.0 * blurRadius * blurRadius + 0.001));
        color += InputTexture.SampleLevel(InputSampler, uv + offset, 0.0) * weight;
        totalWeight += weight;
    }
-   
+
    OutputTexture[id.xy] = (color / totalWeight) * brightness;
 }
 '

--- a/src/SDL3-GPUDemos/SDL3GPUInstancedQuadDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUInstancedQuadDemo.class.st
@@ -32,32 +32,32 @@ Class {
 { #category : 'lifecycle' }
 SDL3GPUInstancedQuadDemo >> close [
 
-	gpuPipeline ifNotNil: [ 
-		gpuDevice releaseGPUGraphicsPipeline: gpuPipeline.
+	gpuPipeline ifNotNil: [
+		gpuPipeline release.
 		gpuPipeline := nil ].
 
-	vertexTransferBuffer ifNotNil: [ 
-		gpuDevice releaseGPUTransferBuffer: vertexTransferBuffer.
+	vertexTransferBuffer ifNotNil: [
+		vertexTransferBuffer release.
 		vertexTransferBuffer := nil ].
-	
-	indexTransferBuffer ifNotNil: [ 
-		gpuDevice releaseGPUTransferBuffer: indexTransferBuffer.
+
+	indexTransferBuffer ifNotNil: [
+		indexTransferBuffer release.
 		indexTransferBuffer := nil ].
 
-	vertexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: vertexBuffer.
+	vertexBuffer ifNotNil: [
+		vertexBuffer release.
 		vertexBuffer := nil ].
 
-	indexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: indexBuffer.
+	indexBuffer ifNotNil: [
+		indexBuffer release.
 		indexBuffer := nil ].
 
-	sampler ifNotNil: [ 
-		gpuDevice releaseGPUSampler: sampler.
+	sampler ifNotNil: [
+		sampler release.
 		sampler := nil ].
 
-	texture ifNotNil: [ 
-		gpuDevice releaseGPUTexture: texture.
+	texture ifNotNil: [
+		texture release.
 		texture := nil ].
 
 	super close
@@ -73,49 +73,33 @@ SDL3GPUInstancedQuadDemo >> decrementQuads [
 ]
 
 { #category : 'rendering' }
-SDL3GPUInstancedQuadDemo >> doRenderPassesOn: swapchainTexture with: aCommandBuffer [
+SDL3GPUInstancedQuadDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 
-	| renderPass |
 	colorTargetInfos first texture: swapchainTexture.
 
-	renderPass :=
-		aCommandBuffer
-			beginGPURenderPassColorTargetInfos: colorTargetInfos
-			depthStencilTargetInfo: nil.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		renderPass
+			pipeline: gpuPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			indexBuffer16Bit: indexBinding;
+			fragmentSamplers: textureSamplerBindings slot: 0.
 
-	renderPass bindGPUGraphicsPipeline: gpuPipeline.
+		uniforms
+			time: Time millisecondClockValue / 1000.0;
+			enableRotation: enableRotation;
+			enableScale: enableScale;
+			numCols: columns;
+			numRows: rows.
 
-	renderPass
-		bindGPUVertexBuffersFirstSlot: 0
-		bindings: vertexBufferBindings.
+		commandBuffer
+			pushVertexUniform: uniforms slot: 0.
 
-	renderPass
-		bindGPUIndexBufferBinding: indexBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-
-	renderPass
-		bindGPUFragmentSamplersFirstSlot: 0
-		textureSamplerBindings: textureSamplerBindings.
-	uniforms 
-		time: Time millisecondClockValue / 1000.0;
-		enableRotation: enableRotation;
-		enableScale: enableScale;
-		numCols: columns;
-		numRows: rows.
-
-	aCommandBuffer
-		pushGPUVertexUniformDataSlotIndex: 0
-		data: uniforms
-		length: uniforms class structureSize.
-
-	renderPass
-		drawGPUIndexedPrimitivesNumIndices: 6
-		numInstances: numberOfQuads
-		firstIndex: 0
-		vertexOffset: 0
-		firstInstance: 0.
-
-	renderPass end
+		renderPass
+			drawIndexedPrimitives: 6
+			instances: numberOfQuads
+			firstIndex: 0
+			vertexOffset: 0
+			firstInstance: 0 ]
 ]
 
 { #category : 'actions' }
@@ -146,20 +130,17 @@ SDL3GPUInstancedQuadDemo >> initialize [
 	enableRotation := 1.0.
 	enableScale := 1.0.
 
-	colorTargetInfos := FFIArray newType: SDL_GPUColorTargetInfo size: 1.
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR.
-	colorTargetInfos first clearColor r: 0.1; g: 0.1; b: 0.1; a: 1.0.
+		beClear: (Color r: 0.1 g: 0.1 b: 0.1).
 
 	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
 
 	textureSamplerBindings := FFIArray newType: SDL_GPUTextureSamplerBinding size: 1.
 
-	indexBinding := SDL_GPUBufferBinding externalNew.
-	indexBinding autoRelease.
+	indexBinding := SDL_GPUBufferBinding offset: 0.
 
-	uniforms := SDL3GPUInstancedQuadUniforms new.
+	uniforms := SDL3GPUInstancedQuadUniforms new
 ]
 
 { #category : 'initialization' }
@@ -175,7 +156,8 @@ SDL3GPUInstancedQuadDemo >> initializeGPUResources [
 { #category : 'initialization' }
 SDL3GPUInstancedQuadDemo >> initializePipeline [
 
-	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets pipelineCreateInfo |
+	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets |
+
 	vertexShader :=
 		SDL3GPUInstancedQuadVertexShaderSource
 			newShaderAmong: shaderFormats
@@ -214,40 +196,21 @@ SDL3GPUInstancedQuadDemo >> initializePipeline [
 		FFIExternalArray
 			externalNewType: SDL_GPUColorTargetDescription
 			size: 1.
-	colorTargets first 
+	colorTargets first
 		format: (gpuDevice getGPUSwapchainTextureFormatIntoWindow: window);
-		blendState:
-			(SDL_GPUColorTargetBlendState new
-				enableBlend: true;
-				srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-				dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-				colorBlendOp: SDL_GPU_BLENDOP_ADD;
-				srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-				dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-				alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-				yourself).
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader;
-		fragmentShader: fragmentShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: colorTargets size.
-	pipelineCreateInfo vertexInputState
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: vertexBindings size;
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: vertexAttributes size.
-
-	gpuPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
+		blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
+	gpuPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
 	"We can free after pipeline was created"
-	gpuDevice releaseGPUShader: vertexShader.
-	gpuDevice releaseGPUShader: fragmentShader.	
-	vertexBindings free.
-	vertexAttributes free.
-	colorTargets free
+	vertexShader release.
+	fragmentShader release.
 ]
 
 { #category : 'initialization' }
@@ -276,6 +239,10 @@ SDL3GPUInstancedQuadDemo >> open [
 
 { #category : 'private' }
 SDL3GPUInstancedQuadDemo >> quadIndices [
+	"Standard index pattern for a quad:
+	Vertices: 0:TL, 1:TR, 2:BR, 3:BL
+	Triangles: (0,1,2) and (0,2,3)"
+
 	^ #(0 1 2 0 2 3)
 ]
 
@@ -288,17 +255,16 @@ SDL3GPUInstancedQuadDemo >> switchSamplerFilter [
 			self isNearestSamplerFilter
 				ifTrue: [ SDL_GPU_FILTER_LINEAR ]
 				ifFalse: [ SDL_GPU_FILTER_NEAREST ].
-		gpuDevice releaseGPUSampler: sampler ].
+		sampler release ].
 
-	sampler := gpuDevice newGPUSamplerCreateinfo:
-		(SDL3GPUSamplerCreateInfo new
+	sampler := gpuDevice newSampler: [ :info |
+		info
 			minFilter: filter;
 			magFilter: filter;
 			mipmapMode: filter;
 			addressModeU: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
 			addressModeV: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-			addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-			yourself).
+			addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE ].
 
 			textureSamplerBindings first sampler: sampler
 
@@ -307,96 +273,79 @@ SDL3GPUInstancedQuadDemo >> switchSamplerFilter [
 { #category : 'initialization' }
 SDL3GPUInstancedQuadDemo >> updateIndexBuffer [
 
-	| mappedAddress indices byteSize commandBuffer |
-	
+	| byteSize |
 	byteSize := 6 * 2. "16-bit indices, 6 indices per quad"
 
 	indexTransferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
-	indexBuffer := gpuDevice 
-		newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
-		size: byteSize.
+	indexBuffer := gpuDevice
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+		               size: byteSize.
 
 	indexBinding buffer: indexBuffer.
 
-	mappedAddress := gpuDevice mapGPUTransferBuffer: indexTransferBuffer cycle: true.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			transferBuffer: indexTransferBuffer
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: 6
+			cycle: true
+			fillWith: [ :indices |
+				1 to: 6 do: [ :j |
+					indices at: j put: (self quadIndices at: j) ] ] ].
 
-	indices := FFIArray fromHandle: mappedAddress type: FFIUInt16 size: 6.
-	
-	1 to: 6 do: [ :j | indices at: j put: (self quadIndices at: j) ].
-
-	gpuDevice unmapGPUTransferBuffer: indexTransferBuffer.
-
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource:
-			(SDL_GPUTransferBufferLocation new
-				transferBuffer: indexTransferBuffer;
-				offset: 0;
-				yourself)
-		destination:
-			(SDL_GPUBufferRegion new
-				buffer: indexBuffer;
-				offset: 0;
-				size: byteSize;
-				yourself)
-		cycle: true;
-		end.
-	commandBuffer submit.
-	
-	gpuDevice releaseGPUTransferBuffer: indexTransferBuffer.
+	indexTransferBuffer release.
 	indexTransferBuffer := nil
 ]
 
 { #category : 'initialization' }
 SDL3GPUInstancedQuadDemo >> updateVertexBuffer [
 
-	| mappedAddress vertices byteSize commandBuffer |
-	
+	| byteSize |
 	byteSize := SDL3GPUQuadVertex structureSize * 4.
 
 	vertexTransferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
-	vertexBuffer := gpuDevice 
-		newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
-		size: byteSize.
+	vertexBuffer := gpuDevice
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		               size: byteSize.
 
 	vertexBufferBindings first buffer: vertexBuffer.
 
-	mappedAddress := gpuDevice mapGPUTransferBuffer: vertexTransferBuffer cycle: true.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
-
-	vertices :=
-		FFIArray
-			fromHandle: mappedAddress
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			transferBuffer: vertexTransferBuffer
+			uploadTo: vertexBuffer
 			type: SDL3GPUQuadVertex
-			size: 4.
-	
-	"Write a single base quad from 0..1 in x and 0..-1 in y"
-	(vertices at: 1) x: 0; y: 0; z: 0; u: 0; v: 0.
-	(vertices at: 2) x: 1; y: 0; z: 0; u: 1; v: 0.
-	(vertices at: 3) x: 1; y: -1; z: 0; u: 1; v: 1.
-	(vertices at: 4) x: 0; y: -1; z: 0; u: 0; v: 1.
+			count: 4
+			cycle: true
+			fillWith: [ :vertices |
+				"Write a single base quad from 0..1 in x and 0..-1 in y"
+				vertices first
+					x: 0;
+					y: 0;
+					z: 0;
+					u: 0;
+					v: 0.
+				vertices second
+					x: 1;
+					y: 0;
+					z: 0;
+					u: 1;
+					v: 0.
+				vertices third
+					x: 1;
+					y: -1;
+					z: 0;
+					u: 1;
+					v: 1.
+				vertices fourth
+					x: 0;
+					y: -1;
+					z: 0;
+					u: 0;
+					v: 1 ] ].
 
-	gpuDevice unmapGPUTransferBuffer: vertexTransferBuffer.
-
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource:
-			(SDL_GPUTransferBufferLocation new
-				transferBuffer: vertexTransferBuffer;
-				offset: 0;
-				yourself)
-		destination:
-			(SDL_GPUBufferRegion new
-				buffer: vertexBuffer;
-				offset: 0;
-				size: byteSize;
-				yourself)
-		cycle: true;
-		end.
-	commandBuffer submit.
-	
-	gpuDevice releaseGPUTransferBuffer: vertexTransferBuffer.
+	vertexTransferBuffer release.
 	vertexTransferBuffer := nil
 ]
 

--- a/src/SDL3-GPUDemos/SDL3GPUInstancedQuadVertexShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUInstancedQuadVertexShaderSource.class.st
@@ -60,10 +60,10 @@ struct VertexOutput {
 
 VertexOutput main(VertexInput input) {
  VertexOutput output;
- 
+
  float col = fmod((float)input.instanceID, numCols);
  float row = floor((float)input.instanceID / numCols);
- 
+
  float zoom = 1.1;
  float quadW = (2.0 / numCols) * zoom;
  float quadH = (2.0 / numRows) * zoom;
@@ -73,7 +73,7 @@ VertexOutput main(VertexInput input) {
  float y_offset = 1.0 - (row * (2.0 / numRows)) + (cos(p) * 0.05);
 
  float2 pos = input.position;
- 
+
  // Center pos before scale/rotate (pos is 0..1 in x, 0..-1 in y)
  pos.x -= 0.5;
  pos.y += 0.5;
@@ -96,13 +96,13 @@ VertexOutput main(VertexInput input) {
  // Uncenter and scale to final size
  pos.x += 0.5;
  pos.y -= 0.5;
- 
+
  pos.x = (pos.x * quadW) + x_offset;
  pos.y = (pos.y * quadH) + y_offset;
 
  output.position = float4(pos, 0.0, 1.0);
  output.uv = input.uv;
- 
+
  float r = fmod(input.instanceID * 0.13, 1.0);
  float g = fmod(input.instanceID * 0.37, 1.0);
  float b = fmod(input.instanceID * 0.71, 1.0);

--- a/src/SDL3-GPUDemos/SDL3GPUMandelbrotComputeShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUMandelbrotComputeShaderSource.class.st
@@ -51,34 +51,34 @@ RWTexture2D<float4> Atlas : register(u0, space1);
 void main(uint3 id : SV_DispatchThreadID) {
    uint width, height;
    Atlas.GetDimensions(width, height);
-   
+
    if (id.x >= p.tileSize || id.y >= p.tileSize) return;
 
    uint atlasWidth = width / p.tileSize;
    uint slotX = p.atlasSlot % atlasWidth;
    uint slotY = p.atlasSlot / atlasWidth;
-   
+
    uint pixelX = slotX * p.tileSize + id.x;
    uint pixelY = slotY * p.tileSize + id.y;
 
    float3 colorSum = float3(0, 0, 0);
-   
+
    // 2x2 Super-sampling for high clarity
    for (int i = 0; i < 2; i++) {
        for (int j = 0; j < 2; j++) {
            float dx = (float(i) + 0.5) * 0.5;
            float dy = (float(j) + 0.5) * 0.5;
-           
+
            float u = (float(id.x) + dx) / float(p.tileSize);
            float v = (float(id.y) + dy) / float(p.tileSize);
-           
+
            float x0 = lerp(p.x1, p.x2, u);
            float y0 = lerp(p.y1, p.y2, v);
-           
+
            float x = 0.0;
            float y = 0.0;
            uint iteration = 0;
-           
+
            // Bailout 16.0 for smoother potential function
            while (x*x + y*y <= 16.0 && iteration < p.maxIterations) {
                float xTemp = x*x - y*y + x0;
@@ -86,7 +86,7 @@ void main(uint3 id : SV_DispatchThreadID) {
                x = xTemp;
                iteration++;
            }
-           
+
            if (iteration == p.maxIterations) {
                colorSum += float3(0, 0, 0);
            } else {
@@ -94,13 +94,13 @@ void main(uint3 id : SV_DispatchThreadID) {
                float log_zn = log(x*x + y*y) / 2.0;
                float nu = log(log_zn / log(2.0)) / log(2.0);
                float t = (float(iteration) + 1.0 - nu) / float(p.maxIterations);
-               
+
                // Enhanced cyclic palette
                colorSum += 0.5 + 0.5 * cos(3.0 + t * 15.0 + float3(0.0, 0.6, 1.0));
            }
        }
    }
-   
+
    Atlas[uint2(pixelX, pixelY)] = float4(colorSum / 4.0, 1.0);
 }
 '

--- a/src/SDL3-GPUDemos/SDL3GPUMandelbrotTiledMapDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUMandelbrotTiledMapDemo.class.st
@@ -50,17 +50,17 @@ Class {
 { #category : 'lifecycle' }
 SDL3GPUMandelbrotTiledMapDemo >> close [
 
-	computePipeline ifNotNil: [ gpuDevice releaseGPUComputePipeline: computePipeline. computePipeline := nil ].
-	quadPipeline ifNotNil: [ gpuDevice releaseGPUGraphicsPipeline: quadPipeline. quadPipeline := nil ].
-	shimmerPipeline ifNotNil: [ gpuDevice releaseGPUGraphicsPipeline: shimmerPipeline. shimmerPipeline := nil ].
-	
-	atlasTexture ifNotNil: [ gpuDevice releaseGPUTexture: atlasTexture. atlasTexture := nil ].
-	sampler ifNotNil: [ gpuDevice releaseGPUSampler: sampler. sampler := nil ].
-	
-	vertexBuffer ifNotNil: [ gpuDevice releaseGPUBuffer: vertexBuffer. vertexBuffer := nil ].
-	indexBuffer ifNotNil: [ gpuDevice releaseGPUBuffer: indexBuffer. indexBuffer := nil ].
-	instanceBuffer ifNotNil: [ gpuDevice releaseGPUBuffer: instanceBuffer. instanceBuffer := nil ].
-	shimmerInstanceBuffer ifNotNil: [ gpuDevice releaseGPUBuffer: shimmerInstanceBuffer. shimmerInstanceBuffer := nil ].
+	computePipeline ifNotNil: [ computePipeline release. computePipeline := nil ].
+	quadPipeline ifNotNil: [ quadPipeline release. quadPipeline := nil ].
+	shimmerPipeline ifNotNil: [ shimmerPipeline release. shimmerPipeline := nil ].
+
+	atlasTexture ifNotNil: [ atlasTexture release. atlasTexture := nil ].
+	sampler ifNotNil: [ sampler release. sampler := nil ].
+
+	vertexBuffer ifNotNil: [ vertexBuffer release. vertexBuffer := nil ].
+	indexBuffer ifNotNil: [ indexBuffer release. indexBuffer := nil ].
+	instanceBuffer ifNotNil: [ instanceBuffer release. instanceBuffer := nil ].
+	shimmerInstanceBuffer ifNotNil: [ shimmerInstanceBuffer release. shimmerInstanceBuffer := nil ].
 
 	super close
 ]
@@ -85,19 +85,19 @@ SDL3GPUMandelbrotTiledMapDemo >> doRenderPassesOn: swapchainTexture with: comman
 
 	self uploadInstanceDataWith: commandBuffer.
 
-	self 
-		executeGraphicsPassOn: swapchainTexture 
-		readyCount: visibleReadyKeys size + visibleFallbackKeys size 
-		loadingCount: visibleLoadingKeys size 
+	self
+		executeGraphicsPassOn: swapchainTexture
+		readyCount: visibleReadyKeys size + visibleFallbackKeys size
+		loadingCount: visibleLoadingKeys size
 		with: commandBuffer
 ]
 
 { #category : 'private' }
-SDL3GPUMandelbrotTiledMapDemo >> evictTilesNotIn: aKeyCollection [
+SDL3GPUMandelbrotTiledMapDemo >> evictTilesNotIn: keys [
 	"Evict tiles that are no longer visible"
 
 	tileStates keys copy do: [ :k |
-		(aKeyCollection includes: k) ifFalse: [
+		(keys includes: k) ifFalse: [
 			tileStates removeKey: k.
 			computedKeys remove: k ifAbsent: [ ].
 			tileToSlotMap at: k ifPresent: [ :slot |
@@ -106,95 +106,96 @@ SDL3GPUMandelbrotTiledMapDemo >> evictTilesNotIn: aKeyCollection [
 ]
 
 { #category : 'private' }
-SDL3GPUMandelbrotTiledMapDemo >> executeComputePassFor: aKeyCollection with: aCommandBuffer [
+SDL3GPUMandelbrotTiledMapDemo >> executeComputePassFor: keys with: commandBuffer [
 
-	| computePass |
-	atlasBindings first texture: atlasTexture.
+	atlasBindings first beTexture: atlasTexture.
 
-	computePass := aCommandBuffer
-				  beginGPUComputePassStorageTextureBindings: atlasBindings
-				  storageBufferBindings: #().
-	computePass bindGPUComputePipeline: computePipeline.
+	commandBuffer computePassTextures: atlasBindings computeStorageBuffers: #() do: [ :computePass |
+		computePass pipeline: computePipeline.
 
-	aKeyCollection do: [ :key | 
-		| slot |
-		slot := tileToSlotMap at: key ifAbsent: [ 0 ].
-		self pushTileUniforms: key slot: slot with: aCommandBuffer.
-		computePass
-			dispatchWorkgroupCountX: tileSizePixels + 15 // 16
-			y: tileSizePixels + 15 // 16
-			z: 1 ].
-
-	computePass end
+		keys do: [ :key |
+			| slot |
+			slot := tileToSlotMap at: key ifAbsent: [ 0 ].
+			self pushTileUniforms: key slot: slot with: commandBuffer.
+			computePass
+				dispatchX: tileSizePixels + 15 // 16
+				y: tileSizePixels + 15 // 16
+				z: 1 ] ]
 ]
 
 { #category : 'private' }
-SDL3GPUMandelbrotTiledMapDemo >> executeGraphicsPassOn: swapchainTexture readyCount: aReadyCount loadingCount: aLoadingCount with: aCommandBuffer [
+SDL3GPUMandelbrotTiledMapDemo >> executeGraphicsPassOn: swapchainTexture readyCount: readyCount loadingCount: loadingCount with: commandBuffer [
 
-	| renderPass |
 	colorTargetInfos first texture: swapchainTexture.
-	renderPass := aCommandBuffer beginGPURenderPassColorTargetInfos: colorTargetInfos depthStencilTargetInfo: nil.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		"Pass A: Ready Tiles (Fractal) - Including Fallbacks"
+		readyCount > 0 ifTrue: [
+			renderPass
+				pipeline: quadPipeline;
+				vertexBuffers: vertexBufferBindings slot: 0;
+				indexBuffer16Bit: indexBufferBinding;
+				fragmentSamplers: samplerBindings slot: 0;
+				drawIndexedPrimitives: 6
+				instances: readyCount
+				firstIndex: 0
+				vertexOffset: 0
+				firstInstance: 0 ].
 
-	"Pass A: Ready Tiles (Fractal) - Including Fallbacks"
-	aReadyCount > 0 ifTrue: [
-		renderPass bindGPUGraphicsPipeline: quadPipeline.
-		renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings.
+		"Pass B: Loading Tiles (Shimmer)"
+		loadingCount > 0 ifTrue: [
+			shimmerUniforms time: Time millisecondClockValue / 1000.0.
+			shimmerUniforms resolutionX: window pixelExtent x; resolutionY: window pixelExtent y.
+			commandBuffer
+				pushVertexUniform: shimmerUniforms slot: 0;
+				pushFragmentUniform: shimmerUniforms slot: 0.
 
-		renderPass bindGPUIndexBufferBinding: indexBufferBinding indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-		renderPass bindGPUFragmentSamplersFirstSlot: 0 textureSamplerBindings: samplerBindings.
-		renderPass drawGPUIndexedPrimitivesNumIndices: 6 numInstances: aReadyCount firstIndex: 0 vertexOffset: 0 firstInstance: 0 ].
-
-	"Pass B: Loading Tiles (Shimmer)"
-	aLoadingCount > 0 ifTrue: [
-		shimmerUniforms time: Time millisecondClockValue / 1000.0.
-		shimmerUniforms resolutionX: window pixelExtent x; resolutionY: window pixelExtent y.
-		aCommandBuffer pushGPUVertexUniformDataSlotIndex: 0 data: shimmerUniforms length: shimmerUniforms class structureSize.
-		aCommandBuffer pushGPUFragmentUniformDataSlotIndex: 0 data: shimmerUniforms length: shimmerUniforms class structureSize.
-		
-		renderPass bindGPUGraphicsPipeline: shimmerPipeline.
-		renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: shimmerVertexBufferBindings.
-		renderPass bindGPUIndexBufferBinding: indexBufferBinding indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-		renderPass drawGPUIndexedPrimitivesNumIndices: 6 numInstances: aLoadingCount firstIndex: 0 vertexOffset: 0 firstInstance: 0 ].
-
-	renderPass end
+			renderPass
+				pipeline: shimmerPipeline;
+				vertexBuffers: shimmerVertexBufferBindings slot: 0;
+				indexBuffer16Bit: indexBufferBinding;
+				drawIndexedPrimitives: 6
+				instances: loadingCount
+				firstIndex: 0
+				vertexOffset: 0
+				firstInstance: 0 ] ]
 ]
 
 { #category : 'private' }
-SDL3GPUMandelbrotTiledMapDemo >> fillInstance: anInstance forKey: aKey slot: aSlotIndex parentKey: aParentKey [
+SDL3GPUMandelbrotTiledMapDemo >> fillInstance: anInstance forKey: key slot: aSlotIndex parentKey: aParentKey [
 
 	| lod fractalTileSize minFractal screenRect atlasRect slotX slotY |
-	lod := aKey third.
+	lod := key third.
 	fractalTileSize := 4.0 / (2 ** lod).
-	minFractal := aKey first * fractalTileSize @ (aKey second * fractalTileSize).
-	
+	minFractal := key first * fractalTileSize @ (key second * fractalTileSize).
+
 	"Map fractal coord back to logical 0..1 based on camera"
 	screenRect := camera fractalToLogicalRect: (minFractal extent: fractalTileSize @ fractalTileSize).
-		
+
 	slotX := aSlotIndex \\ atlasSizeSlots x.
 	slotY := aSlotIndex // atlasSizeSlots x.
-	
+
 	"Base atlas rect for the slot"
-	atlasRect := SDL3FRect new 
-		x: slotX asFloat / atlasSizeSlots x asFloat; 
-		y: slotY asFloat / atlasSizeSlots y asFloat; 
-		w: 1.0 / atlasSizeSlots x asFloat; 
+	atlasRect := SDL3FRect new
+		x: slotX asFloat / atlasSizeSlots x asFloat;
+		y: slotY asFloat / atlasSizeSlots y asFloat;
+		w: 1.0 / atlasSizeSlots x asFloat;
 		h: 1.0 / atlasSizeSlots y asFloat;
 		yourself.
 
 	"If using a parent slot, we must only use a quadrant of it"
 	aParentKey ifNotNil: [ | subX subY |
-		subX := aKey first \\ 2.
-		subY := aKey second \\ 2.
-		atlasRect 
+		subX := key first \\ 2.
+		subY := key second \\ 2.
+		atlasRect
 			x: atlasRect x + (subX * 0.5 * atlasRect w);
 			y: atlasRect y + (subY * 0.5 * atlasRect h);
 			w: atlasRect w * 0.5;
 			h: atlasRect h * 0.5 ].
 
-	anInstance screenRect 
-		x: screenRect left asFloat; 
-		y: screenRect top asFloat; 
-		w: screenRect width asFloat; 
+	anInstance screenRect
+		x: screenRect left asFloat;
+		y: screenRect top asFloat;
+		w: screenRect width asFloat;
 		h: screenRect height asFloat.
 	anInstance atlasRect
 		x: atlasRect x;
@@ -216,63 +217,48 @@ SDL3GPUMandelbrotTiledMapDemo >> initialize [
 
 	tileSizePixels := 512.
 	atlasSizeSlots := 8 @ 8. "4096x4096 atlas"
-	
+
 	camera := SDL3TiledMapCamera new.
-	camera 
+	camera
 		viewportExtent: self initialExtent;
 		center: -0.5 @ 0.0;
 		zoomLevel: 1.5.
-	
+
 	tileManager := SDL3TileManager new.
 	tileManager camera: camera.
 
-	colorTargetInfos := FFIExternalArray
-					externalNewType: SDL_GPUColorTargetInfo
-					size: 1.
-	colorTargetInfos autoRelease.
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR;
-		updateClearColorFrom: (Color r: 0.02 g: 0.02 b: 0.05).
+		beClear: (Color r: 0.02 g: 0.02 b: 0.05).
 
-	atlasBindings := FFIExternalArray
-				externalNewType:
-				SDL_GPUStorageTextureReadWriteBinding
-				size: 1.
-	atlasBindings autoRelease.
-	atlasBindings first cycle: false.
+	atlasBindings := SDL3GPUStorageTextureReadWriteBinding safeNewArray: 1.
+	atlasBindings first beUnbound.
 
-	uniforms := SDL3GPUMandelbrotUniforms externalNew.
-	uniforms autoRelease.
-	
-	shimmerUniforms := SDL3GPUShimmerUniforms externalNew.
-	shimmerUniforms autoRelease.
+	uniforms := SDL3GPUMandelbrotUniforms safeNew.
+
+	shimmerUniforms := SDL3GPUShimmerUniforms safeNew.
 	shimmerUniforms
 		baseColor: (SDL3FColor r: 0.1 g: 0.1 b: 0.15 a: 1.0);
 		highlightColor: (SDL3FColor r: 0.2 g: 0.2 b: 0.3 a: 1.0);
 		effectType: 2; "Angled Sweep"
 		cornerRadius: 0.0. "Perfectly square tiles"
-	
+
 	tileToSlotMap := Dictionary new.
 	freeSlots := (0 to: (atlasSizeSlots x * atlasSizeSlots y - 1)) asOrderedCollection.
-	
-	vertexBufferBindings := FFIExternalArray externalNewType: SDL_GPUBufferBinding size: 2.
-	vertexBufferBindings autoRelease.
 
-	shimmerVertexBufferBindings := FFIExternalArray externalNewType: SDL_GPUBufferBinding size: 2.
-	shimmerVertexBufferBindings autoRelease.
-	
-	indexBufferBinding := SDL_GPUBufferBinding externalNew.
-	indexBufferBinding autoRelease.
-	
-	samplerBindings := FFIExternalArray externalNewType: SDL_GPUTextureSamplerBinding size: 1.
-	samplerBindings autoRelease.
-	
+	vertexBufferBindings := SDL_GPUBufferBinding safeNewArray: 2.
+
+	shimmerVertexBufferBindings := SDL_GPUBufferBinding safeNewArray: 2.
+
+	indexBufferBinding := SDL_GPUBufferBinding offset: 0.
+
+	samplerBindings := SDL_GPUTextureSamplerBinding safeNewArray: 1.
+
 	loadingDelayMillis := 250.
 	tileStates := Dictionary new.
 	loadedKeysQueue := SharedQueue new.
 	computedKeys := Set new.
-	
+
 	visibleReadyKeys := OrderedCollection new.
 	visibleFallbackKeys := OrderedCollection new.
 	visibleLoadingKeys := OrderedCollection new
@@ -281,89 +267,112 @@ SDL3GPUMandelbrotTiledMapDemo >> initialize [
 { #category : 'initialization' }
 SDL3GPUMandelbrotTiledMapDemo >> initializeAtlas [
 
-	| createInfo |
-	createInfo := SDL3GPUTextureCreateInfo externalNew.
-	createInfo
-		type: SDL_GPU_TEXTURETYPE_2D;
-		format: SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
-		width: atlasSizeSlots x * tileSizePixels;
-		height: atlasSizeSlots y * tileSizePixels;
-		layerCountOrDepth: 1;
-		numLevels: 1;
-		usage: SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE.
-	
-	atlasTexture := gpuDevice newGPUTextureCreateinfo: createInfo.
-	createInfo free.
+	atlasTexture := gpuDevice newTexture: [ :info |
+		info
+			type: SDL_GPU_TEXTURETYPE_2D;
+			format: SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+			width: atlasSizeSlots x * tileSizePixels;
+			height: atlasSizeSlots y * tileSizePixels;
+			layerCountOrDepth: 1;
+			numLevels: 1;
+			usage: SDL_GPU_TEXTUREUSAGE_SAMPLER | SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE ].
 
-	sampler := gpuDevice newGPUSamplerCreateinfo: (SDL3GPUSamplerCreateInfo externalNew
-		minFilter: SDL_GPU_FILTER_LINEAR;
-		magFilter: SDL_GPU_FILTER_LINEAR;
-		mipmapMode: SDL_GPU_SAMPLERMIPMAPMODE_LINEAR;
-		addressModeU: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-		addressModeV: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-		addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-		yourself)
+	sampler := gpuDevice newSampler: [ :info |
+		info
+			minFilter: SDL_GPU_FILTER_LINEAR;
+			magFilter: SDL_GPU_FILTER_LINEAR;
+			mipmapMode: SDL_GPU_SAMPLERMIPMAPMODE_LINEAR;
+			addressModeU: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+			addressModeV: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+			addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE ]
 ]
 
 { #category : 'initialization' }
 SDL3GPUMandelbrotTiledMapDemo >> initializeGeometry [
 	"Upload a standard 1x1 quad (0..1)."
 
-	| vertices indices vTransfer iTransfer mappedAddress vSize iSize copyCommandBuffer |
+	self
+		initializeQuadBuffers;
+		initializeInstanceBuffers;
+		setupGeometryBindings
+]
 
-	vSize := 4 * SDL3GPUQuadVertex structureSize.
-	vertexBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX size: vSize.
-	vTransfer := gpuDevice newUploadTransferBuffer: vSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: vTransfer cycle: false.
-	vertices := FFIArray fromHandle: mappedAddress type: SDL3GPUQuadVertex size: 4.
-	(vertices at: 1) x: 0.0; y: 0.0; z: 0.0; u: 0.0; v: 0.0.
-	(vertices at: 2) x: 1.0; y: 0.0; z: 0.0; u: 1.0; v: 0.0.
-	(vertices at: 3) x: 1.0; y: 1.0; z: 0.0; u: 1.0; v: 1.0.
-	(vertices at: 4) x: 0.0; y: 1.0; z: 0.0; u: 0.0; v: 1.0.
-	gpuDevice unmapGPUTransferBuffer: vTransfer.
-
-	iSize := 6 * 2.
-	indexBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX size: iSize.
-	iTransfer := gpuDevice newUploadTransferBuffer: iSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: iTransfer cycle: false.
-	indices := FFIArray fromHandle: mappedAddress type: FFIUInt16 size: 6.
-	indices at: 1 put: 0; at: 2 put: 1; at: 3 put: 2; at: 4 put: 0; at: 5 put: 2; at: 6 put: 3.
-	gpuDevice unmapGPUTransferBuffer: iTransfer.
-
-	copyCommandBuffer := gpuDevice acquireGPUCommandBuffer.
-	copyCommandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: vTransfer; offset: 0; yourself) destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: vSize; yourself) cycle: false;
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: iTransfer; offset: 0; yourself) destination: (SDL_GPUBufferRegion new buffer: indexBuffer; offset: 0; size: iSize; yourself) cycle: false;
-		end.
-	copyCommandBuffer submit.
-	
-	gpuDevice releaseGPUTransferBuffer: vTransfer.
-	gpuDevice releaseGPUTransferBuffer: iTransfer.
+{ #category : 'initialization' }
+SDL3GPUMandelbrotTiledMapDemo >> initializeInstanceBuffers [
 
 	"Pre-allocate instance buffers for up to 256 tiles"
-	instanceBuffer := gpuDevice 
-		newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX 
-		size: 256 * SDL3GPUTileInstance structureSize.
+	instanceBuffer := gpuDevice
+		                  newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                  size: 256 * SDL3GPUTileInstance structureSize.
 
-	shimmerInstanceBuffer := gpuDevice 
-		newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX 
-		size: 256 * SDL3GPUTileInstance structureSize.
+	shimmerInstanceBuffer := gpuDevice
+		                         newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                         size: 256 * SDL3GPUTileInstance structureSize
+]
 
-	vertexBufferBindings first buffer: vertexBuffer; offset: 0.
-	vertexBufferBindings second buffer: instanceBuffer; offset: 0.
+{ #category : 'initialization' }
+SDL3GPUMandelbrotTiledMapDemo >> initializeQuadBuffers [
 
-	shimmerVertexBufferBindings first buffer: vertexBuffer; offset: 0.
-	shimmerVertexBufferBindings second buffer: shimmerInstanceBuffer; offset: 0.
+	vertexBuffer := gpuDevice
+		                newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                size: 4 * SDL3GPUQuadVertex structureSize.
 
-	indexBufferBinding buffer: indexBuffer; offset: 0.
+	indexBuffer := gpuDevice
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+		               size: 6 * 2.
 
-	samplerBindings first texture: atlasTexture; sampler: sampler
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: vertexBuffer
+			type: SDL3GPUQuadVertex
+			count: 4
+			cycle: false
+			fillWith: [ :vertices |
+				vertices first
+					x: 0.0;
+					y: 0.0;
+					z: 0.0;
+					u: 0.0;
+					v: 0.0.
+				vertices second
+					x: 1.0;
+					y: 0.0;
+					z: 0.0;
+					u: 1.0;
+					v: 0.0.
+				vertices third
+					x: 1.0;
+					y: 1.0;
+					z: 0.0;
+					u: 1.0;
+					v: 1.0.
+				vertices fourth
+					x: 0.0;
+					y: 1.0;
+					z: 0.0;
+					u: 0.0;
+					v: 1.0 ].
+
+		uploader
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: 6
+			cycle: false
+			fillWith: [ :indices |
+				indices
+					at: 1 put: 0;
+					at: 2 put: 1;
+					at: 3 put: 2;
+					at: 4 put: 0;
+					at: 5 put: 2;
+					at: 6 put: 3 ] ]
 ]
 
 { #category : 'private' }
 SDL3GPUMandelbrotTiledMapDemo >> initializeQuadPipelineWith: formats colorTargets: colorTargets [
 
-	| quadVertexSource quadFragmentSource vertexBindings vertexAttributes pipelineCreateInfo |
+	| quadVertexSource quadFragmentSource vertexBindings vertexAttributes |
+
 	quadVertexSource := SDL3GPUTiledMapVertexShaderSource
 							newShaderAmong: formats
 							device: gpuDevice.
@@ -376,27 +385,17 @@ SDL3GPUMandelbrotTiledMapDemo >> initializeQuadPipelineWith: formats colorTarget
 	vertexBindings := self newTiledMapVertexBindings.
 	vertexAttributes := self newTiledMapVertexAttributes.
 
-	pipelineCreateInfo := SDL3GPUGraphicsPipelineCreateInfo externalNew.
-	pipelineCreateInfo autoRelease.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: quadVertexSource;
-		fragmentShader: quadFragmentSource.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: 1;
-		hasDepthStencilTarget: false.
-	pipelineCreateInfo vertexInputState
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: 4;
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: 2.
+	quadPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: quadVertexSource
+			fragment: quadFragmentSource
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
-	quadPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo:
-						pipelineCreateInfo.
-
-	gpuDevice releaseGPUShader: quadVertexSource.
-	gpuDevice releaseGPUShader: quadFragmentSource
+	quadVertexSource release.
+	quadFragmentSource release
 ]
 
 { #category : 'initialization' }
@@ -409,7 +408,7 @@ SDL3GPUMandelbrotTiledMapDemo >> initializeShaders [
 						  newComputePipelineAmong: formats
 						  device: gpuDevice.
 
-	colorTargets := self newColorTargetDescriptions: 1.
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
 	colorTargets first format:
 		(gpuDevice getGPUSwapchainTextureFormatIntoWindow: window).
 
@@ -420,7 +419,8 @@ SDL3GPUMandelbrotTiledMapDemo >> initializeShaders [
 { #category : 'private' }
 SDL3GPUMandelbrotTiledMapDemo >> initializeShimmerPipelineWith: formats colorTargets: colorTargets [
 
-	| shimmerVertexSource shimmerFragmentSource shimmerVertexBindings shimmerVertexAttributes pipelineCreateInfo |
+	| shimmerVertexSource shimmerFragmentSource shimmerVertexBindings shimmerVertexAttributes |
+
 	shimmerVertexSource := SDL3GPUShimmerVertexShaderSource
 							  newShaderAmong: formats
 							  device: gpuDevice.
@@ -428,50 +428,30 @@ SDL3GPUMandelbrotTiledMapDemo >> initializeShimmerPipelineWith: formats colorTar
 								newShaderAmong: formats
 								device: gpuDevice.
 
-	colorTargets first blendState: (SDL_GPUColorTargetBlendState new
-			enableBlend: true;
-			srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-			dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-			colorBlendOp: SDL_GPU_BLENDOP_ADD;
-			srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE;
-			dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ZERO;
-			alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-			yourself).
+	colorTargets first blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
 
 	shimmerVertexBindings := self newTiledMapVertexBindings.
 	shimmerVertexAttributes := self newTiledMapVertexAttributes.
 
-	pipelineCreateInfo := SDL3GPUGraphicsPipelineCreateInfo externalNew.
-	pipelineCreateInfo autoRelease.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: shimmerVertexSource;
-		fragmentShader: shimmerFragmentSource.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: 1;
-		hasDepthStencilTarget: false.
-	pipelineCreateInfo vertexInputState
-		vertexAttributes: shimmerVertexAttributes;
-		numVertexAttributes: 4;
-		vertexBufferDescriptions: shimmerVertexBindings;
-		numVertexBuffers: 2.
+	shimmerPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: shimmerVertexSource
+			fragment: shimmerFragmentSource
+			targets: colorTargets.
+		info vertexInputState
+			attributes: shimmerVertexAttributes
+			bindings: shimmerVertexBindings ].
 
-	shimmerPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo:
-						  pipelineCreateInfo.
-
-	gpuDevice releaseGPUShader: shimmerVertexSource.
-	gpuDevice releaseGPUShader: shimmerFragmentSource
+	shimmerVertexSource release.
+	shimmerFragmentSource release
 ]
 
 { #category : 'private' }
 SDL3GPUMandelbrotTiledMapDemo >> newTiledMapVertexAttributes [
 
 	| vertexAttributes |
-	vertexAttributes := FFIExternalArray
-							externalNewType: SDL_GPUVertexAttribute
-							size: 4.
-	vertexAttributes autoRelease.
+	vertexAttributes := SDL_GPUVertexAttribute safeNewArray: 4.
+
 	vertexAttributes first
 		bufferSlot: 0;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
@@ -482,16 +462,17 @@ SDL3GPUMandelbrotTiledMapDemo >> newTiledMapVertexAttributes [
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
 		location: 1;
 		offset: 3 * FFIFloat32 externalTypeSize.
-	(vertexAttributes at: 3)
+	vertexAttributes third
 		bufferSlot: 1;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4;
 		location: 2;
 		offset: 0.
-	(vertexAttributes at: 4)
+	vertexAttributes fourth
 		bufferSlot: 1;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4;
 		location: 3;
 		offset: 4 * FFIFloat32 externalTypeSize.
+
 	^ vertexAttributes
 ]
 
@@ -499,20 +480,20 @@ SDL3GPUMandelbrotTiledMapDemo >> newTiledMapVertexAttributes [
 SDL3GPUMandelbrotTiledMapDemo >> newTiledMapVertexBindings [
 
 	| vertexBindings |
-	vertexBindings := FFIExternalArray
-						 externalNewType: SDL_GPUVertexBufferDescription
-						 size: 2.
-	vertexBindings autoRelease.
+	vertexBindings := SDL_GPUVertexBufferDescription safeNewArray: 2.
+
 	vertexBindings first
 		slot: 0;
 		pitch: SDL3GPUQuadVertex structureSize;
 		inputRate: SDL_GPU_VERTEXINPUTRATE_VERTEX;
 		instanceStepRate: 0.
+
 	vertexBindings second
 		slot: 1;
 		pitch: SDL3GPUTileInstance structureSize;
 		inputRate: SDL_GPU_VERTEXINPUTRATE_INSTANCE;
 		instanceStepRate: 0.
+
 	^ vertexBindings
 ]
 
@@ -532,59 +513,85 @@ SDL3GPUMandelbrotTiledMapDemo >> processLoadedKeysQueue [
 	| toProcess |
 	toProcess := OrderedCollection new.
 	[ loadedKeysQueue isEmpty ] whileFalse: [ toProcess add: loadedKeysQueue next ].
-	
+
 	toProcess do: [ :loadedKey |
 		(tileStates includesKey: loadedKey) ifTrue: [
 			freeSlots ifNotEmpty: [
 				tileToSlotMap at: loadedKey put: freeSlots removeFirst.
-				tileStates at: loadedKey put: #ready.
+				tileStates at: loadedKey put: #ready
 			] ifEmpty: [
-				loadedKeysQueue nextPut: loadedKey.
-			].
-		].
+				loadedKeysQueue nextPut: loadedKey
+			]
+		]
 	]
 ]
 
 { #category : 'private' }
-SDL3GPUMandelbrotTiledMapDemo >> pushTileUniforms: aKey slot: aSlot with: aCommandBuffer [
+SDL3GPUMandelbrotTiledMapDemo >> pushTileUniforms: key slot: slot with: commandBuffer [
 	"Push compute uniforms for a specific tile."
-	
+
 	| lod fractalTileSize minX minY |
-	lod := aKey third.
+	lod := key third.
 	fractalTileSize := 4.0 / (2 ** lod).
-	
-	minX := aKey first * fractalTileSize.
-	minY := aKey second * fractalTileSize.
-	
-	uniforms 
+
+	minX := key first * fractalTileSize.
+	minY := key second * fractalTileSize.
+
+	uniforms
 		x1: minX asFloat;
 		y1: minY asFloat;
 		x2: (minX + fractalTileSize) asFloat;
 		y2: (minY + fractalTileSize) asFloat;
 		maxIterations: 256;
-		atlasSlot: aSlot;
+		atlasSlot: slot;
 		tileSize: tileSizePixels.
-		
-	aCommandBuffer pushGPUComputeUniformDataSlotIndex: 0 data: uniforms length: SDL3GPUMandelbrotUniforms structureSize
+
+	commandBuffer pushComputeUniform: uniforms slot: 0
 ]
 
 { #category : 'private' }
-SDL3GPUMandelbrotTiledMapDemo >> requestTile: aKey [
+SDL3GPUMandelbrotTiledMapDemo >> requestTile: key [
 	"Emulate loading latency with jitter."
-	
+
 	| jitteredDelay |
 	loadingDelayMillis = 0 ifTrue: [
 		freeSlots ifNotEmpty: [
-			tileToSlotMap at: aKey put: freeSlots removeFirst.
-			^ tileStates at: aKey put: #ready ] ].
-	
+			tileToSlotMap at: key put: freeSlots removeFirst.
+			^ tileStates at: key put: #ready ] ].
+
 	"Emulate latency to load tiles (50% to 150% of the base parameter)"
 	jitteredDelay := (loadingDelayMillis * 0.5) +
 		(loadingDelayMillis * SharedRandom globalGenerator next).
 	[	(Delay forMilliseconds: jitteredDelay truncated) wait.
-		loadedKeysQueue nextPut: aKey ] forkAt: Processor activePriority + 1.
-	
-	^ tileStates at: aKey put: #loading
+		loadedKeysQueue nextPut: key ] forkAt: Processor activePriority + 1.
+
+	^ tileStates at: key put: #loading
+]
+
+{ #category : 'initialization' }
+SDL3GPUMandelbrotTiledMapDemo >> setupGeometryBindings [
+
+	vertexBufferBindings first
+		buffer: vertexBuffer;
+		offset: 0.
+	vertexBufferBindings second
+		buffer: instanceBuffer;
+		offset: 0.
+
+	shimmerVertexBufferBindings first
+		buffer: vertexBuffer;
+		offset: 0.
+	shimmerVertexBufferBindings second
+		buffer: shimmerInstanceBuffer;
+		offset: 0.
+
+	indexBufferBinding
+		buffer: indexBuffer;
+		offset: 0.
+
+	samplerBindings first
+		texture: atlasTexture;
+		sampler: sampler
 ]
 
 { #category : 'hooks' }
@@ -602,7 +609,7 @@ SDL3GPUMandelbrotTiledMapDemo >> updateTiles [
 
 	| visibleKeys |
 	visibleKeys := tileManager visibleTileKeys.
-	
+
 	self evictTilesNotIn: visibleKeys.
 	self processLoadedKeysQueue.
 
@@ -618,7 +625,7 @@ SDL3GPUMandelbrotTiledMapDemo >> updateTiles [
 			ifFalse: [
 				"Check for fallback parent"
 				parentKey := { key first // 2. key second // 2. key third - 1 }.
-				(tileStates at: parentKey ifAbsent: [ nil ]) = #ready 
+				(tileStates at: parentKey ifAbsent: [ nil ]) = #ready
 					ifTrue: [ visibleFallbackKeys add: { key . parentKey } ]
 					ifFalse: [ visibleLoadingKeys add: key ]
 			] ]
@@ -627,61 +634,84 @@ SDL3GPUMandelbrotTiledMapDemo >> updateTiles [
 { #category : 'accessing' }
 SDL3GPUMandelbrotTiledMapDemo >> updatedTitle [
 
-	| readyCount loadingCount |
+	| readyCount loadingCount zoomString |
 	readyCount := tileStates values count: [ :each | each = #ready ].
 	loadingCount := tileStates values count: [ :each | each = #loading ].
+	zoomString := camera zoomLevel printShowingDecimalPlaces: 2.
 
-	^ super updatedTitle, (' - Emulated Latency: {1}ms - Zoom: {2} - Tiles: {3} ready, {4} loading' 
-		format: { 
-			loadingDelayMillis. 
-			camera zoomLevel printShowingDecimalPlaces: 2.
-			readyCount.
-			loadingCount })
+	^ String streamContents: [ :stream |
+		  stream
+			  nextPutAll: super updatedTitle;
+			  nextPutAll: ' - Latency: ';
+			  nextPutAll: loadingDelayMillis printString;
+			  nextPutAll: 'ms - Zoom: ';
+			  nextPutAll: zoomString;
+			  nextPutAll: ' - Tiles: ';
+			  nextPutAll: readyCount printString;
+			  nextPutAll: ' ready, ';
+			  nextPutAll: loadingCount printString;
+			  nextPutAll: ' loading' ]
 ]
 
 { #category : 'private' }
-SDL3GPUMandelbrotTiledMapDemo >> uploadInstanceDataWith: aCommandBuffer [
+SDL3GPUMandelbrotTiledMapDemo >> uploadInstanceDataWith: commandBuffer [
 
-	| transfer mapped size idx |
-	
-	"1. Ready and Fallback instances (shared buffer)"
+	self
+		uploadReadyInstanceDataWith: commandBuffer;
+		uploadShimmerInstanceDataWith: commandBuffer
+]
+
+{ #category : 'private' }
+SDL3GPUMandelbrotTiledMapDemo >> uploadReadyInstanceDataWith: commandBuffer [
+
+	| size |
 	size := visibleReadyKeys size + visibleFallbackKeys size.
-	size > 0 ifTrue: [
-		transfer := gpuDevice newUploadTransferBuffer: size * SDL3GPUTileInstance structureSize.
-		mapped := FFIArray fromHandle: (gpuDevice mapGPUTransferBuffer: transfer cycle: false) type: SDL3GPUTileInstance size: size.
-		idx := 1.
-		visibleReadyKeys do: [ :key |
-			self fillInstance: (mapped at: idx) forKey: key slot: (tileToSlotMap at: key) parentKey: nil.
-			idx := idx + 1 ].
-		visibleFallbackKeys do: [ :pair |
-			self fillInstance: (mapped at: idx) forKey: pair first slot: (tileToSlotMap at: pair second) parentKey: pair second.
-			idx := idx + 1 ].
-		gpuDevice unmapGPUTransferBuffer: transfer.
-		[ :copyPass |
-			copyPass uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transfer; offset: 0; yourself) 
-				destination: (SDL_GPUBufferRegion new buffer: instanceBuffer; offset: 0; size: size * SDL3GPUTileInstance structureSize; yourself) 
-				cycle: false.
-			copyPass end.
-		] value: aCommandBuffer beginGPUCopyPass.
-		gpuDevice releaseGPUTransferBuffer: transfer ].
+	size = 0 ifTrue: [ ^ self ].
 
-	"2. Loading (Shimmer) instances"
+	commandBuffer uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: instanceBuffer
+			type: SDL3GPUTileInstance
+			count: size
+			cycle: false
+			fillWith: [ :mapped |
+				| idx |
+				idx := 1.
+				visibleReadyKeys do: [ :key |
+					self
+						fillInstance: (mapped at: idx)
+						forKey: key
+						slot: (tileToSlotMap at: key)
+						parentKey: nil.
+					idx := idx + 1 ].
+				visibleFallbackKeys do: [ :pair |
+					self
+						fillInstance: (mapped at: idx)
+						forKey: pair first
+						slot: (tileToSlotMap at: pair second)
+						parentKey: pair second.
+					idx := idx + 1 ] ] ]
+]
+
+{ #category : 'private' }
+SDL3GPUMandelbrotTiledMapDemo >> uploadShimmerInstanceDataWith: commandBuffer [
+
+	| size |
 	size := visibleLoadingKeys size.
-	size > 0 ifTrue: [
-		transfer := gpuDevice newUploadTransferBuffer: size * SDL3GPUTileInstance structureSize.
-		mapped := FFIArray fromHandle: (gpuDevice mapGPUTransferBuffer: transfer cycle: false) type: SDL3GPUTileInstance size: size.
-		idx := 1.
-		visibleLoadingKeys do: [ :key |
-			self fillInstance: (mapped at: idx) forKey: key slot: 0 parentKey: nil.
-			idx := idx + 1 ].
-		gpuDevice unmapGPUTransferBuffer: transfer.
-		[ :copyPass |
-			copyPass uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transfer; offset: 0; yourself) 
-				destination: (SDL_GPUBufferRegion new buffer: shimmerInstanceBuffer; offset: 0; size: size * SDL3GPUTileInstance structureSize; yourself) 
-				cycle: false.
-			copyPass end.
-		] value: aCommandBuffer beginGPUCopyPass.
-		gpuDevice releaseGPUTransferBuffer: transfer ]
+	size = 0 ifTrue: [ ^ self ].
+
+	commandBuffer uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: shimmerInstanceBuffer
+			type: SDL3GPUTileInstance
+			count: size
+			cycle: false
+			fillWith: [ :mapped |
+				| idx |
+				idx := 1.
+				visibleLoadingKeys do: [ :key |
+					self fillInstance: (mapped at: idx) forKey: key slot: 0 parentKey: nil.
+					idx := idx + 1 ] ] ]
 ]
 
 { #category : 'hooks' }

--- a/src/SDL3-GPUDemos/SDL3GPUNodeForceDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUNodeForceDemo.class.st
@@ -35,52 +35,48 @@ Class {
 }
 
 { #category : 'private' }
-SDL3GPUNodeForceDemo >> bindSharedGraphicsResourcesTo: aRenderPass with: aCommandBuffer [
+SDL3GPUNodeForceDemo >> bindSharedGraphicsResourcesTo: renderPass with: commandBuffer [
 
-	aRenderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings.
-	aRenderPass
-		bindGPUVertexStorageBuffersFirstSlot: 0
-		storageBuffers: storageBuffers.
-	aRenderPass
-		bindGPUIndexBufferBinding: indexBufferBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
+	renderPass
+		vertexBuffers: vertexBufferBindings slot: 0;
+		vertexStorageBuffers: storageBuffers slot: 0;
+		indexBuffer16Bit: indexBufferBinding.
 
-	uniforms aspectRatio: window extent x asFloat / (window extent y max: 1).
-	uniforms selectedNodeIndex: selectedNodeIndex.
-	aCommandBuffer
-		pushGPUVertexUniformDataSlotIndex: 0
-		data: uniforms
-		length: SDL3GPUNodeForceUniforms structureSize
+	uniforms
+		aspectRatio: window extent x asFloat / (window extent y max: 1);
+		selectedNodeIndex: selectedNodeIndex.
+	commandBuffer
+		pushVertexUniform: uniforms slot: 0
 ]
 
 { #category : 'lifecycle' }
 SDL3GPUNodeForceDemo >> close [
 
 	nodesBufferPing ifNotNil: [
-		gpuDevice releaseGPUBuffer: nodesBufferPing.
+		nodesBufferPing release.
 		nodesBufferPing := nil ].
 	nodesBufferPong ifNotNil: [
-		gpuDevice releaseGPUBuffer: nodesBufferPong.
+		nodesBufferPong release.
 		nodesBufferPong := nil ].
 	edgesBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: edgesBuffer.
+		edgesBuffer release.
 		edgesBuffer := nil ].
 
 	vertexBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: vertexBuffer.
+		vertexBuffer release.
 		vertexBuffer := nil ].
 	indexBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: indexBuffer.
+		indexBuffer release.
 		indexBuffer := nil ].
 
 	computePipeline ifNotNil: [
-		gpuDevice releaseGPUComputePipeline: computePipeline.
+		computePipeline release.
 		computePipeline := nil ].
 	nodePipeline ifNotNil: [
-		gpuDevice releaseGPUGraphicsPipeline: nodePipeline.
+		nodePipeline release.
 		nodePipeline := nil ].
 	edgePipeline ifNotNil: [
-		gpuDevice releaseGPUGraphicsPipeline: edgePipeline.
+		edgePipeline release.
 		edgePipeline := nil ].
 
 	super close
@@ -111,48 +107,39 @@ SDL3GPUNodeForceDemo >> computeSimulation [
 ]
 
 { #category : 'rendering' }
-SDL3GPUNodeForceDemo >> doRenderPassesOn: aTexture with: aCommandBuffer [
+SDL3GPUNodeForceDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 
-	| renderPass colorTargetInfos |
-	colorTargetInfos := FFIExternalArray externalNewType: SDL_GPUColorTargetInfo size: 1.
-	colorTargetInfos autoRelease.
+	| colorTargetInfos |
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		texture: aTexture;
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR;
-		updateClearColorFrom: Color black.
+		beClearTexture: swapchainTexture
+		color: Color black.
 
-	renderPass := aCommandBuffer
-					 beginGPURenderPassColorTargetInfos: colorTargetInfos
-					 depthStencilTargetInfo: nil.
-
-	self bindSharedGraphicsResourcesTo: renderPass with: aCommandBuffer.
-	self drawEdgesOn: renderPass.
-	self drawNodesOn: renderPass.
-
-	renderPass end
-
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		self bindSharedGraphicsResourcesTo: renderPass with: commandBuffer.
+		self drawEdgesOn: renderPass.
+		self drawNodesOn: renderPass ]
 ]
 
 { #category : 'private' }
-SDL3GPUNodeForceDemo >> drawEdgesOn: aRenderPass [
+SDL3GPUNodeForceDemo >> drawEdgesOn: renderPass [
 
-	aRenderPass bindGPUGraphicsPipeline: edgePipeline.
-	aRenderPass
-		drawGPUIndexedPrimitivesNumIndices: 6
-		numInstances: numEdges
+	renderPass pipeline: edgePipeline.
+	renderPass
+		drawIndexedPrimitives: 6
+		instances: numEdges
 		firstIndex: 0
 		vertexOffset: 0
 		firstInstance: 0
 ]
 
 { #category : 'private' }
-SDL3GPUNodeForceDemo >> drawNodesOn: aRenderPass [
+SDL3GPUNodeForceDemo >> drawNodesOn: renderPass [
 
-	aRenderPass bindGPUGraphicsPipeline: nodePipeline.
-	aRenderPass
-		drawGPUIndexedPrimitivesNumIndices: 6
-		numInstances: numNodes
+	renderPass pipeline: nodePipeline.
+	renderPass
+		drawIndexedPrimitives: 6
+		instances: numNodes
 		firstIndex: 0
 		vertexOffset: 0
 		firstInstance: 0
@@ -161,55 +148,29 @@ SDL3GPUNodeForceDemo >> drawNodesOn: aRenderPass [
 { #category : 'private' }
 SDL3GPUNodeForceDemo >> executeSimulationComputePassWith: commandBuffer input: inputBuffer output: outputBuffer [
 
-	| computePass |
 	storageBufferBindings first
 		buffer: outputBuffer;
 		cycle: false.
-	computePass := commandBuffer
-					  beginGPUComputePassStorageTextureBindings: #()
-					  storageBufferBindings: storageBufferBindings.
 
-	storageBuffers at: 1 put: currentNodesBuffer getHandle.
-	storageBuffers at: 2 put: edgesBuffer getHandle.
+	commandBuffer computePassTextures: #() computeStorageBuffers: storageBufferBindings do: [ :computePass |
+		storageBuffers
+			at: 1 put: inputBuffer getHandle;
+			at: 2 put: edgesBuffer getHandle.
 
-	computePass
-		bindGPUComputePipeline: computePipeline;
-		bindGPUComputeStorageBuffersFirstSlot: 0
-		storageBuffers: storageBuffers;
-		dispatchWorkgroupCountX: numNodes + 63 // 64
-		y: 1
-		z: 1;
-		end
+		computePass
+			pipeline: computePipeline;
+			computeStorageBuffers: storageBuffers slot: 0;
+			dispatchX: numNodes + 63 // 64
+			y: 1
+			z: 1 ]
 ]
 
 { #category : 'private' }
-SDL3GPUNodeForceDemo >> fillIndexTransfer: aTransfer [
+SDL3GPUNodeForceDemo >> findNodeAtSimulationPosition: point among: nodes [
 
-	| mappedAddress indices |
-	mappedAddress := gpuDevice mapGPUTransferBuffer: aTransfer cycle: false.
-	indices := FFIArray fromHandle: mappedAddress type: #uint16 size: 6.
-	#( 0 1 2 0 2 3 ) withIndexDo: [ :val :idx | indices at: idx put: val ].
-	gpuDevice unmapGPUTransferBuffer: aTransfer
-]
-
-{ #category : 'private' }
-SDL3GPUNodeForceDemo >> fillVertexTransfer: aTransfer [
-
-	| mappedAddress |
-	mappedAddress := gpuDevice mapGPUTransferBuffer: aTransfer cycle: false.
-	#( (0 0) (1 0) (1 1) (0 1) ) withIndexDo: [ :uv :idx |
-		| v |
-		v := SDL3GPUQuadVertex fromHandle: mappedAddress + ((idx - 1) * SDL3GPUQuadVertex structureSize).
-		v x: uv first asFloat; y: uv second asFloat; z: 0.0; u: uv first asFloat; v: uv second asFloat ].
-	gpuDevice unmapGPUTransferBuffer: aTransfer
-]
-
-{ #category : 'private' }
-SDL3GPUNodeForceDemo >> findNodeAtSimulationPosition: aPoint among: aNodeArray [
-
-	aNodeArray withIndexDo: [ :node :i |
+	nodes withIndexDo: [ :node :i |
 		| distance |
-		distance := (node x @ node y) distanceTo: aPoint.
+		distance := (node x @ node y) distanceTo: point.
 		distance < node radius ifTrue: [ ^ i - 1 ] ].
 
 	^ -1
@@ -222,9 +183,9 @@ SDL3GPUNodeForceDemo >> initialize [
 
 	numNodes := 64.
 	numEdges := 128.
-	
+
 	self initializeUniforms.
-	self initializeGPUStateContainers.
+	self initializeGPUStateContainers
 ]
 
 { #category : 'initialization' }
@@ -259,51 +220,24 @@ SDL3GPUNodeForceDemo >> initializeBuffers [
 { #category : 'initialization' }
 SDL3GPUNodeForceDemo >> initializeGPUStateContainers [
 
-	storageBuffers := FFIExternalArray externalNewType: ExternalAddress size: 2.
-	storageBuffers autoRelease.
-	
-	storageBufferBindings := FFIExternalArray externalNewType: SDL_GPUStorageBufferReadWriteBinding size: 1.
-	storageBufferBindings autoRelease.
+	storageBuffers := ExternalAddress safeNewArray: 2.
 
-	vertexBufferBindings := FFIExternalArray externalNewType: SDL_GPUBufferBinding size: 1.
-	vertexBufferBindings autoRelease.
+
+	storageBufferBindings := SDL3GPUStorageBufferReadWriteBinding safeNewArray: 1.
+
+	vertexBufferBindings := SDL_GPUBufferBinding safeNewArray: 1.
 
 	selectedNodeIndex := -1.
 
-	isDragging := false.
+	isDragging := false
 ]
 
 { #category : 'initialization' }
 SDL3GPUNodeForceDemo >> initializeGeometry [
 
-	| vSize iSize vTransfer iTransfer |
-	vSize := 4 * SDL3GPUQuadVertex structureSize.
-	iSize := 6 * 2.
-
-	vertexBuffer := gpuDevice
-		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
-		               size: vSize.
-	indexBuffer := gpuDevice
-		              newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
-		              size: iSize.
-
-	vTransfer := gpuDevice newUploadTransferBuffer: vSize.
-	iTransfer := gpuDevice newUploadTransferBuffer: iSize.
-
-	self fillVertexTransfer: vTransfer.
-	self fillIndexTransfer: iTransfer.
-	self uploadVertex: vTransfer index: iTransfer.
-
-	gpuDevice releaseGPUTransferBuffer: vTransfer.
-	gpuDevice releaseGPUTransferBuffer: iTransfer.
-
-	vertexBufferBindings first
-		buffer: vertexBuffer;
-		offset: 0.
-	indexBufferBinding := SDL_GPUBufferBinding externalNew
-		                     buffer: indexBuffer;
-		                     yourself.
-	indexBufferBinding autoRelease
+	self
+		initializeQuadBuffers;
+		setupGeometryBindings
 ]
 
 { #category : 'initialization' }
@@ -311,7 +245,7 @@ SDL3GPUNodeForceDemo >> initializeGraph [
 
 	| random |
 	random := Random seed: 17.
-	
+
 	nodeArray := FFIArray newType: SDL3GPUNode size: numNodes.
 	nodeArray do: [ :node |
 		node x: (random next * 1.0 - 0.5); y: (random next * 1.0 - 0.5).
@@ -319,15 +253,52 @@ SDL3GPUNodeForceDemo >> initializeGraph [
 		node radius: 0.02 + (random next * 0.03).
 		node hue: random next.
 		node isSelected: 0 ].
-		
+
 	edgeArray := FFIArray newType: SDL3GPUEdge size: numEdges.
 	edgeArray do: [ :edge |
 		edge nodeA: (random nextInteger: numNodes) - 1.
 		edge nodeB: (random nextInteger: numNodes) - 1.
 		edge weight: 0.5 + random next.
 		"Avoid self-loops for simplicity"
-		[ edge nodeA = edge nodeB ] whileTrue: [ 
+		[ edge nodeA = edge nodeB ] whileTrue: [
 			edge nodeB: (random nextInteger: numNodes) - 1 ] ]
+]
+
+{ #category : 'initialization' }
+SDL3GPUNodeForceDemo >> initializeQuadBuffers [
+
+	vertexBuffer := gpuDevice
+		                newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                size: 4 * SDL3GPUQuadVertex structureSize.
+
+	indexBuffer := gpuDevice
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+		               size: 6 * 2.
+
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: vertexBuffer
+			type: SDL3GPUQuadVertex
+			count: 4
+			cycle: false
+			fillWith: [ :vertices |
+				#( (0 0) (1 0) (1 1) (0 1) ) withIndexDo: [ :uv :idx |
+					| v |
+					v := vertices at: idx.
+					v x: uv first asFloat;
+					  y: uv second asFloat;
+					  z: 0.0;
+					  u: uv first asFloat;
+					  v: uv second asFloat ] ].
+
+		uploader
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: 6
+			cycle: false
+			fillWith: [ :indices |
+				#( 0 1 2 0 2 3 ) withIndexDo: [ :val :idx |
+					indices at: idx put: val ] ] ]
 ]
 
 { #category : 'initialization' }
@@ -339,7 +310,7 @@ SDL3GPUNodeForceDemo >> initializeShaders [
 						  newComputePipelineAmong: formats
 						  device: gpuDevice.
 
-	colorTargets := self newColorTargetDescriptions: 1.
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
 	colorTargets first format:
 		(gpuDevice getGPUSwapchainTextureFormatIntoWindow: window).
 
@@ -350,8 +321,7 @@ SDL3GPUNodeForceDemo >> initializeShaders [
 { #category : 'initialization' }
 SDL3GPUNodeForceDemo >> initializeUniforms [
 
-	uniforms := SDL3GPUNodeForceUniforms externalNew.
-	uniforms autoRelease.
+	uniforms := SDL3GPUNodeForceUniforms safeNew.
 	uniforms
 		numNodes: numNodes;
 		numEdges: numEdges;
@@ -369,23 +339,9 @@ SDL3GPUNodeForceDemo >> initializeUniforms [
 ]
 
 { #category : 'private' }
-SDL3GPUNodeForceDemo >> newAlphaBlendState [
-
-	^ SDL_GPUColorTargetBlendState new
-		 enableBlend: true;
-		 srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-		 dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-		 colorBlendOp: SDL_GPU_BLENDOP_ADD;
-		 srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE;
-		 dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ZERO;
-		 alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-		 yourself
-]
-
-{ #category : 'private' }
 SDL3GPUNodeForceDemo >> newEdgePipelineWith: aFormatArray colorTargets: colorTargets [
 
-	| vertexShader fragmentShader pipelineCreateInfo |
+	| vertexShader fragmentShader vertexBindings vertexAttributes |
 	vertexShader := SDL3GPUEdgeVertexShaderSource
 						newShaderAmong: aFormatArray
 						device: gpuDevice.
@@ -393,48 +349,28 @@ SDL3GPUNodeForceDemo >> newEdgePipelineWith: aFormatArray colorTargets: colorTar
 						 newShaderAmong: aFormatArray
 						 device: gpuDevice.
 
-	colorTargets first blendState: self newAlphaBlendState.
+	colorTargets first blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
 
-	pipelineCreateInfo := self
-							 newGraphicsPipelineCreateInfoFor: vertexShader
-							 colorTargets: colorTargets.
-	pipelineCreateInfo fragmentShader: fragmentShader.
-
-	edgePipeline := gpuDevice newGPUGraphicsPipelineCreateinfo:
-						pipelineCreateInfo.
-	gpuDevice
-		releaseGPUShader: vertexShader;
-		releaseGPUShader: fragmentShader
-]
-
-{ #category : 'private' }
-SDL3GPUNodeForceDemo >> newGraphicsPipelineCreateInfoFor: vertexShader colorTargets: colorTargets [
-
-	| pipelineCreateInfo vertexBindings vertexAttributes |
 	vertexBindings := self newNodeVertexBindings.
 	vertexAttributes := self newNodeVertexAttributes.
 
-	pipelineCreateInfo := SDL3GPUGraphicsPipelineCreateInfo externalNew.
-	pipelineCreateInfo autoRelease.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: 1;
-		hasDepthStencilTarget: false.
-	pipelineCreateInfo vertexInputState
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: 2;
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: 1.
-	^ pipelineCreateInfo
+	edgePipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
+
+	vertexShader release.
+	fragmentShader release
 ]
 
 { #category : 'private' }
 SDL3GPUNodeForceDemo >> newNodePipelineWith: aFormatArray colorTargets: colorTargets [
 
-	| vertexShader fragmentShader pipelineCreateInfo |
+	| vertexShader fragmentShader vertexBindings vertexAttributes |
 	vertexShader := SDL3GPUNodeVertexShaderSource
 						newShaderAmong: aFormatArray
 						device: gpuDevice.
@@ -442,37 +378,42 @@ SDL3GPUNodeForceDemo >> newNodePipelineWith: aFormatArray colorTargets: colorTar
 						 newShaderAmong: aFormatArray
 						 device: gpuDevice.
 
-	colorTargets first blendState: self newAlphaBlendState.
+	colorTargets first blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
 
-	pipelineCreateInfo := self
-							 newGraphicsPipelineCreateInfoFor: vertexShader
-							 colorTargets: colorTargets.
-	pipelineCreateInfo fragmentShader: fragmentShader.
+	vertexBindings := self newNodeVertexBindings.
+	vertexAttributes := self newNodeVertexAttributes.
 
-	nodePipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
-	gpuDevice
-		releaseGPUShader: vertexShader;
-		releaseGPUShader: fragmentShader
+	nodePipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
+
+	vertexShader release.
+	fragmentShader release
 ]
 
 { #category : 'private' }
 SDL3GPUNodeForceDemo >> newNodeVertexAttributes [
 
 	| vertexAttributes |
-	vertexAttributes := FFIExternalArray
-							externalNewType: SDL_GPUVertexAttribute
-							size: 2.
-	vertexAttributes autoRelease.
+	vertexAttributes := SDL_GPUVertexAttribute safeNewArray: 2.
+
 	vertexAttributes first
 		bufferSlot: 0;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
 		location: 0;
 		offset: 0.
+
 	vertexAttributes second
 		bufferSlot: 0;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
 		location: 1;
 		offset: 3 * FFIFloat32 externalTypeSize.
+
 	^ vertexAttributes
 ]
 
@@ -480,15 +421,14 @@ SDL3GPUNodeForceDemo >> newNodeVertexAttributes [
 SDL3GPUNodeForceDemo >> newNodeVertexBindings [
 
 	| vertexBindings |
-	vertexBindings := FFIExternalArray
-						 externalNewType: SDL_GPUVertexBufferDescription
-						 size: 1.
-	vertexBindings autoRelease.
+	vertexBindings := SDL_GPUVertexBufferDescription safeNewArray: 1.
+
 	vertexBindings first
 		slot: 0;
 		pitch: SDL3GPUQuadVertex structureSize;
 		inputRate: SDL_GPU_VERTEXINPUTRATE_VERTEX;
 		instanceStepRate: 0.
+
 	^ vertexBindings
 ]
 
@@ -517,58 +457,43 @@ SDL3GPUNodeForceDemo >> pushSimulationUniformsTo: commandBuffer [
 		isDragging: (isDragging ifTrue: [ 1 ] ifFalse: [ 0 ]).
 
 	commandBuffer
-		pushGPUComputeUniformDataSlotIndex: 0
-		data: uniforms
-		length: SDL3GPUNodeForceUniforms structureSize
+		pushComputeUniform: uniforms slot: 0
 ]
 
 { #category : 'actions' }
-SDL3GPUNodeForceDemo >> selectNodeAtSimulationPosition: aPoint [
+SDL3GPUNodeForceDemo >> selectNodeAtSimulationPosition: point [
 
-	| nodesSize transfer mappedNodes |
-	nodesSize := numNodes * SDL3GPUNode structureSize.
-	transfer := gpuDevice newDownloadTransferBuffer: nodesSize.
+	gpuDevice
+		downloadFrom: currentNodesBuffer
+		type: SDL3GPUNode
+		count: numNodes
+		do: [ :mappedNodes |
+			selectedNodeIndex := self
+				                     findNodeAtSimulationPosition: point
+				                     among: mappedNodes ].
 
-	gpuDevice acquireGPUCommandBuffer in: [ :commandBuffer | 
-		| copyPass |
-		copyPass := commandBuffer beginGPUCopyPass.
-		copyPass
-			downloadFromGPUBufferSource: (SDL_GPUBufferRegion new
-					buffer: currentNodesBuffer;
-					offset: 0;
-					size: nodesSize;
-					yourself)
-			destination: (SDL_GPUTransferBufferLocation new
-					transferBuffer: transfer;
-					offset: 0;
-					yourself).
-		copyPass end.
-		commandBuffer submit ].
-
-	gpuDevice waitForGPUIdle.
-
-	mappedNodes := FFIArray
-		              fromHandle:
-		              (gpuDevice mapGPUTransferBuffer: transfer cycle: false)
-		              type: SDL3GPUNode
-		              size: numNodes.
-	selectedNodeIndex := self
-		                    findNodeAtSimulationPosition: aPoint
-		                    among: mappedNodes.
-
-	gpuDevice unmapGPUTransferBuffer: transfer.
-	gpuDevice releaseGPUTransferBuffer: transfer.
 	self updateTitle
 ]
 
+{ #category : 'initialization' }
+SDL3GPUNodeForceDemo >> setupGeometryBindings [
+
+	vertexBufferBindings first
+		buffer: vertexBuffer;
+		offset: 0.
+	indexBufferBinding := SDL_GPUBufferBinding
+		                      buffer: indexBuffer
+		                      offset: 0
+]
+
 { #category : 'private' }
-SDL3GPUNodeForceDemo >> simulationPositionFromWindowPoint: aPoint [
+SDL3GPUNodeForceDemo >> simulationPositionFromWindowPoint: point [
 
 	| nx ny winExtent aspect bx by |
 	winExtent := window extent.
-	nx := aPoint x / (winExtent x max: 1) asFloat.
-	ny := aPoint y / (winExtent y max: 1) asFloat.
-	
+	nx := point x / (winExtent x max: 1) asFloat.
+	ny := point y / (winExtent y max: 1) asFloat.
+
 	aspect := winExtent x asFloat / (winExtent y max: 1).
 	bx := 1.0 max: aspect.
 	by := 1.0 max: (1.0 / aspect).
@@ -588,14 +513,14 @@ SDL3GPUNodeForceDemo >> step [
 SDL3GPUNodeForceDemo >> updatedTitle [
 
 	| selectionInfo dragInfo |
-	selectionInfo := selectedNodeIndex >= 0 
+	selectionInfo := selectedNodeIndex >= 0
 		ifTrue: [ ' | Selected: {1}' format: { selectedNodeIndex } ]
 		ifFalse: [ '' ].
 	dragInfo := isDragging ifTrue: [ ' [DRAGGING]' ] ifFalse: [ '' ].
 
-	^ super updatedTitle, (' - Nodes: {1} Edges: {2} (Spring: {3} Repel: {4} Damp: {5}){6}{7}' format: { 
+	^ super updatedTitle, (' - Nodes: {1} Edges: {2} (Spring: {3} Repel: {4} Damp: {5}){6}{7}' format: {
 		numNodes.
-		numEdges. 
+		numEdges.
 		uniforms springStiffness printShowingDecimalPlaces: 1.
 		uniforms repulsionWeight printShowingDecimalPlaces: 1.
 		uniforms damping printShowingDecimalPlaces: 4.
@@ -606,95 +531,25 @@ SDL3GPUNodeForceDemo >> updatedTitle [
 { #category : 'private' }
 SDL3GPUNodeForceDemo >> uploadEdges [
 
-	| edgesSize transfer mappedAddress |
-	edgesSize := numEdges * SDL3GPUEdge structureSize.
-	transfer := gpuDevice newUploadTransferBuffer: edgesSize.
-
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transfer cycle: false.
-	LibC memCopy: edgeArray getHandle to: mappedAddress size: edgesSize.
-	gpuDevice unmapGPUTransferBuffer: transfer.
-
-	gpuDevice acquireGPUCommandBuffer in: [ :commandBuffer | 
-		| copyPass |
-		copyPass := commandBuffer beginGPUCopyPass.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: transfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: edgesBuffer;
-					offset: 0;
-					size: edgesSize;
-					yourself)
-			cycle: false.
-		copyPass end.
-		commandBuffer submit ].
-
-	gpuDevice releaseGPUTransferBuffer: transfer
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: edgesBuffer
+			type: SDL3GPUEdge
+			count: numEdges
+			cycle: false
+			fromPointer: edgeArray getHandle ]
 ]
 
 { #category : 'private' }
 SDL3GPUNodeForceDemo >> uploadNodes [
 
-	| nodesSize transfer mappedAddress |
-	nodesSize := numNodes * SDL3GPUNode structureSize.
-	transfer := gpuDevice newUploadTransferBuffer: nodesSize.
-
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transfer cycle: false.
-	LibC memCopy: nodeArray getHandle to: mappedAddress size: nodesSize.
-	gpuDevice unmapGPUTransferBuffer: transfer.
-
-	gpuDevice acquireGPUCommandBuffer in: [ :commandBuffer | 
-		| copyPass |
-		copyPass := commandBuffer beginGPUCopyPass.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: transfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: nodesBufferPing;
-					offset: 0;
-					size: nodesSize;
-					yourself)
-			cycle: false.
-		copyPass end.
-		commandBuffer submit ].
-
-	gpuDevice releaseGPUTransferBuffer: transfer
-]
-
-{ #category : 'private' }
-SDL3GPUNodeForceDemo >> uploadVertex: vTransfer index: iTransfer [
-
-	| copyCB copyPass |
-	copyCB := gpuDevice acquireGPUCommandBuffer.
-	copyPass := copyCB beginGPUCopyPass.
-	copyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-				transferBuffer: vTransfer;
-				offset: 0;
-				yourself)
-		destination: (SDL_GPUBufferRegion new
-				buffer: vertexBuffer;
-				offset: 0;
-				size: 4 * SDL3GPUQuadVertex structureSize;
-				yourself)
-		cycle: false.
-	copyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-				transferBuffer: iTransfer;
-				offset: 0;
-				yourself)
-		destination: (SDL_GPUBufferRegion new
-				buffer: indexBuffer;
-				offset: 0;
-				size: 6 * 2;
-				yourself)
-		cycle: false.
-	copyPass end.
-	copyCB submit
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: nodesBufferPing
+			type: SDL3GPUNode
+			count: numNodes
+			cycle: false
+			fromPointer: nodeArray getHandle ]
 ]
 
 { #category : 'hooks' }
@@ -710,7 +565,7 @@ SDL3GPUNodeForceDemo >> visitKeyboardDownEvent: aKeyboardDownEvent [
 	key = SDLK_LEFT asInteger ifTrue: [ uniforms repulsionWeight: (uniforms repulsionWeight - 0.1 max: 0.0) ].
 	key = SDLK_PAGEUP asInteger ifTrue: [ uniforms damping: (uniforms damping * 1.5 min: 0.99) ].
 	key = SDLK_PAGEDOWN asInteger ifTrue: [ uniforms damping: (uniforms damping / 1.5 max: 0.00001) ].
-	
+
 	self updateTitle
 ]
 
@@ -745,5 +600,5 @@ SDL3GPUNodeForceDemo >> visitMouseMotionEvent: aMouseMotionEvent [
 
 	simPosition := self simulationPositionFromWindowPoint: aMouseMotionEvent position.
 	uniforms hoverX: simPosition x.
-	uniforms hoverY: simPosition y.
+	uniforms hoverY: simPosition y
 ]

--- a/src/SDL3-GPUDemos/SDL3GPUQuadDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUQuadDemo.class.st
@@ -30,35 +30,35 @@ Class {
 { #category : 'lifecycle' }
 SDL3GPUQuadDemo >> close [
 
-	gpuPipeline ifNotNil: [ 
-		gpuDevice releaseGPUGraphicsPipeline: gpuPipeline.
+	gpuPipeline ifNotNil: [
+		gpuPipeline release.
 		gpuPipeline := nil ].
 
-	vertexTransferBuffer ifNotNil: [ 
-		gpuDevice releaseGPUTransferBuffer: vertexTransferBuffer.
+	vertexTransferBuffer ifNotNil: [
+		vertexTransferBuffer release.
 		vertexTransferBuffer := nil ].
-	
-	indexTransferBuffer ifNotNil: [ 
-		gpuDevice releaseGPUTransferBuffer: indexTransferBuffer.
+
+	indexTransferBuffer ifNotNil: [
+		indexTransferBuffer release.
 		indexTransferBuffer := nil ].
 
-	vertexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: vertexBuffer.
+	vertexBuffer ifNotNil: [
+		vertexBuffer release.
 		vertexBuffer := nil ].
 
-	indexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: indexBuffer.
+	indexBuffer ifNotNil: [
+		indexBuffer release.
 		indexBuffer := nil ].
 
-	sampler ifNotNil: [ 
-		gpuDevice releaseGPUSampler: sampler.
+	sampler ifNotNil: [
+		sampler release.
 		sampler := nil ].
 
-	texture ifNotNil: [ 
-		gpuDevice releaseGPUTexture: texture.
+	texture ifNotNil: [
+		texture release.
 		texture := nil ].
 
-	
+
 	super close
 ]
 
@@ -72,41 +72,26 @@ SDL3GPUQuadDemo >> decrementQuads [
 ]
 
 { #category : 'rendering' }
-SDL3GPUQuadDemo >> doRenderPassesOn: swapchainTexture with: aCommandBuffer [
+SDL3GPUQuadDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 
-	| animatedHue renderPass |
+	| animatedHue |
 	colorTargetInfos first texture: swapchainTexture.
 
 	"Animate background hue to show blending"
 	animatedHue := (Time millisecondClockValue / 20.0) \\ 360.
 	colorTargetInfos first clearColor updateFrom: (Color h: animatedHue s: 0.8 v: 0.3).
 
-	renderPass :=
-		aCommandBuffer
-			beginGPURenderPassColorTargetInfos: colorTargetInfos
-			depthStencilTargetInfo: nil.
-
-	renderPass bindGPUGraphicsPipeline: gpuPipeline.
-
-	renderPass
-		bindGPUVertexBuffersFirstSlot: 0
-		bindings: vertexBufferBindings.
-
-	renderPass
-		bindGPUIndexBufferBinding: indexBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-
-	renderPass
-		bindGPUFragmentSamplersFirstSlot: 0
-		textureSamplerBindings: textureSamplerBindings.
-	renderPass
-		drawGPUIndexedPrimitivesNumIndices: self indicesCount
-		numInstances: 1
-		firstIndex: 0
-		vertexOffset: 0
-		firstInstance: 0.
-
-	renderPass end
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		renderPass
+			pipeline: gpuPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			indexBuffer16Bit: indexBinding;
+			fragmentSamplers: textureSamplerBindings slot: 0;
+			drawIndexedPrimitives: self indicesCount
+			instances: 1
+			firstIndex: 0
+			vertexOffset: 0
+			firstInstance: 0 ]
 ]
 
 { #category : 'actions' }
@@ -146,17 +131,15 @@ SDL3GPUQuadDemo >> initialize [
 	vertexBufferSize := 0.
 	indexBufferSize := 0.
 
-	colorTargetInfos := FFIArray newType: SDL_GPUColorTargetInfo size: 1.
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR.
+		beClear: Color black.
 
 	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
 
 	textureSamplerBindings := FFIArray newType: SDL_GPUTextureSamplerBinding size: 1.
 
-	indexBinding := SDL_GPUBufferBinding externalNew.
-	indexBinding autoRelease
+	indexBinding := SDL_GPUBufferBinding offset: 0
 ]
 
 { #category : 'initialization' }
@@ -172,7 +155,7 @@ SDL3GPUQuadDemo >> initializeGPUResources [
 { #category : 'initialization' }
 SDL3GPUQuadDemo >> initializePipeline [
 
-	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets pipelineCreateInfo |
+	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets |
 	vertexShader :=
 		SDL3GPUQuadVertexShaderSource
 			newShaderAmong: shaderFormats
@@ -211,37 +194,26 @@ SDL3GPUQuadDemo >> initializePipeline [
 		FFIExternalArray
 			externalNewType: SDL_GPUColorTargetDescription
 			size: 1.
-	colorTargets first 
+	colorTargets first
 		format: (gpuDevice getGPUSwapchainTextureFormatIntoWindow: window);
-		blendState:
-			(SDL_GPUColorTargetBlendState new
-				enableBlend: true;
-				srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-				dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-				colorBlendOp: SDL_GPU_BLENDOP_ADD;
-				srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-				dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-				alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-				yourself).
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader;
-		fragmentShader: fragmentShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: colorTargets size.
-	pipelineCreateInfo vertexInputState
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: vertexBindings size;
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: vertexAttributes size.
-
-	gpuPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
+		blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
+	gpuPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+			vertexShader: vertexShader;
+			fragmentShader: fragmentShader.
+		info targetInfo
+			colorTargetDescriptions: colorTargets;
+			numColorTargets: colorTargets size.
+		info vertexInputState
+			vertexBufferDescriptions: vertexBindings;
+			numVertexBuffers: vertexBindings size;
+			vertexAttributes: vertexAttributes;
+			numVertexAttributes: vertexAttributes size ].
 
 	"We can free after pipeline was created"
-	gpuDevice releaseGPUShader: vertexShader.
-	gpuDevice releaseGPUShader: fragmentShader.	
+	vertexShader release.
+	fragmentShader release.
 	vertexBindings free.
 	vertexAttributes free.
 	colorTargets free
@@ -282,10 +254,10 @@ SDL3GPUQuadDemo >> open [
 
 { #category : 'private' }
 SDL3GPUQuadDemo >> quadIndices [
-	"Standard 16-bit index pattern for a quad:
+	"Standard index pattern for a quad:
 	Vertices: 0:TL, 1:TR, 2:BR, 3:BL
-	Triangles: (0,1,2) and (0,2,3)
-	"
+	Triangles: (0,1,2) and (0,2,3)"
+
 	^ #(0 1 2 0 2 3)
 ]
 
@@ -305,154 +277,115 @@ SDL3GPUQuadDemo >> switchSamplerFilter [
 			self isNearestSamplerFilter
 				ifTrue: [ SDL_GPU_FILTER_LINEAR ]
 				ifFalse: [ SDL_GPU_FILTER_NEAREST ].
-		gpuDevice releaseGPUSampler: sampler ].
+		sampler release ].
 
-	sampler := gpuDevice newGPUSamplerCreateinfo:
-		(SDL3GPUSamplerCreateInfo new
+	sampler := gpuDevice newSampler: [ :info |
+		info
 			minFilter: filter;
 			magFilter: filter;
 			mipmapMode: filter;
 			addressModeU: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
 			addressModeV: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-			addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-			yourself).
+			addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE ].
 
 			textureSamplerBindings first sampler: sampler
 .
-	
+
 	self updateTitle
 ]
 
 { #category : 'initialization' }
 SDL3GPUQuadDemo >> updateIndexBuffer [
 
-	| mappedAddress indices byteSize commandBuffer |
-	
+	| byteSize |
 	byteSize := self indicesCount * 2. "16-bit indices"
 
 	"1. Initialize buffer (or recreate if number of quads changed)"
 	indexBufferSize = byteSize ifFalse: [
-
 		indexBuffer ifNotNil: [
-			gpuDevice releaseGPUBuffer: indexBuffer.
-			gpuDevice releaseGPUTransferBuffer: indexTransferBuffer ].
+			indexBuffer release.
+			indexTransferBuffer release ].
 
 		indexTransferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
 
-		indexBuffer := gpuDevice 
-			newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
-			size: byteSize.
+		indexBuffer := gpuDevice
+			               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+			               size: byteSize.
 
 		indexBinding buffer: indexBuffer.
 		indexBufferSize := byteSize ].
 
 	"2. Upload new data"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: indexTransferBuffer cycle: true.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
-
-	indices := FFIArray fromHandle: mappedAddress type: FFIUInt16 size: self indicesCount.
-	
-	1 to: numberOfQuads do: [ :i |
-		| baseVertex baseIndex |
-		baseVertex := (i - 1) * self numberOfVerticesPerQuad.
-		baseIndex := (i - 1) * 6.
-		1 to: 6 do: [ :j |
-			indices at: baseIndex + j put: baseVertex + (self quadIndices at: j) ] ].
-
-	gpuDevice unmapGPUTransferBuffer: indexTransferBuffer.
-
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource:
-			(SDL_GPUTransferBufferLocation new
-				transferBuffer: indexTransferBuffer;
-				offset: 0;
-				yourself)
-		destination:
-			(SDL_GPUBufferRegion new
-				buffer: indexBuffer;
-				offset: 0;
-				size: byteSize;
-				yourself)
-		cycle: true;
-		end.
-	commandBuffer submit
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			transferBuffer: indexTransferBuffer
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: self indicesCount
+			cycle: true
+			fillWith: [ :indices |
+				1 to: numberOfQuads do: [ :i |
+					| baseVertex baseIndex |
+					baseVertex := (i - 1) * self numberOfVerticesPerQuad.
+					baseIndex := (i - 1) * 6.
+					1 to: 6 do: [ :j |
+						indices
+							at: baseIndex + j
+							put: baseVertex + (self quadIndices at: j) ] ] ] ]
 ]
 
 { #category : 'initialization' }
 SDL3GPUQuadDemo >> updateVertexBuffer [
 
-	| mappedAddress vertices byteSize commandBuffer cols rows quadW quadH phase zoom |
-	
+	| byteSize cols rows quadW quadH phase zoom |
 	"1. Determine Grid Layout"
 	cols := numberOfQuads sqrt ceiling.
 	rows := (numberOfQuads / cols) ceiling.
 	zoom := 1.1. "Increase zoom to overlap quads"
 	quadW := (2.0 / cols) * zoom.
 	quadH := (2.0 / rows) * zoom.
-	
+
 	byteSize := SDL3GPUQuadVertex structureSize * self verticesCount.
 
 	"2. Initialize buffer (or recreate if number of quads changed)"
 	vertexBufferSize = byteSize ifFalse: [
-
 		vertexBuffer ifNotNil: [
-			gpuDevice releaseGPUBuffer: vertexBuffer.
-			gpuDevice releaseGPUTransferBuffer: vertexTransferBuffer ].
+			vertexBuffer release.
+			vertexTransferBuffer release ].
 
 		vertexTransferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
 
-		vertexBuffer := gpuDevice 
-			newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
-			size: byteSize.
+		vertexBuffer := gpuDevice
+			               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+			               size: byteSize.
 
 		vertexBufferBindings first buffer: vertexBuffer.
 		vertexBufferSize := byteSize ].
 
 	"3. Upload new data (Using CYCLE: TRUE for animation)"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: vertexTransferBuffer cycle: true.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
-
-	vertices :=
-		FFIArray
-			fromHandle: mappedAddress
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			transferBuffer: vertexTransferBuffer
+			uploadTo: vertexBuffer
 			type: SDL3GPUQuadVertex
-			size: self verticesCount.
-	
-	phase := Time millisecondClockValue / 500.0.
-	1 to: numberOfQuads do: [ :i |
-		| col row x y p |
-		p := phase + (i * 0.3).
-		row := (i - 1) // cols + 1.
-		col := (i - 1) \\ cols + 1.
-		x := -1.0 + ((col - 1) * (2.0 / cols)) + (p sin * 0.05).
-		y := 1.0 - ((row - 1) * (2.0 / rows)) + (p cos * 0.05).
-		self
-			writeQuadTo: vertices
-			at: (i - 1) * self numberOfVerticesPerQuad + 1 
-			x: x
-			y: y
-			w: quadW
-			h: quadH ].
-
-	gpuDevice unmapGPUTransferBuffer: vertexTransferBuffer.
-
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource:
-			(SDL_GPUTransferBufferLocation new
-				transferBuffer: vertexTransferBuffer;
-				offset: 0;
-				yourself)
-		destination:
-			(SDL_GPUBufferRegion new
-				buffer: vertexBuffer;
-				offset: 0;
-				size: byteSize;
-				yourself)
-		cycle: true;
-		end.
-	commandBuffer submit
+			count: self verticesCount
+			cycle: true
+			fillWith: [ :vertices |
+				phase := Time millisecondClockValue / 500.0.
+				1 to: numberOfQuads do: [ :i |
+					| col row x y p |
+					p := phase + (i * 0.3).
+					row := (i - 1) // cols + 1.
+					col := (i - 1) \\ cols + 1.
+					x := -1.0 + ((col - 1) * (2.0 / cols)) + (p sin * 0.05).
+					y := 1.0 - ((row - 1) * (2.0 / rows)) + (p cos * 0.05).
+					self
+						writeQuadTo: vertices
+						at: (i - 1) * self numberOfVerticesPerQuad + 1
+						x: x
+						y: y
+						w: quadW
+						h: quadH ] ] ]
 ]
 
 { #category : 'accessing' }
@@ -490,7 +423,7 @@ SDL3GPUQuadDemo >> writeQuadTo: aVertexArray at: startIndex x: x y: y w: w h: h 
 	| v |
 	"Vertices (NDC): y increases UPWARDS.
 	UVs: y increases DOWNWARDS.
-	
+
 	0: TL: x, y	   UV: 0, 0
 	1: TR: x+w, y	 UV: 1, 0
 	2: BR: x+w, y-h   UV: 1, 1
@@ -508,5 +441,5 @@ SDL3GPUQuadDemo >> writeQuadTo: aVertexArray at: startIndex x: x y: y w: w h: h 
 	v x: x + w; y: y - h; z: 0; u: 1; v: 1.
 	"3: BL"
 	v := aVertexArray at: startIndex + 3.
-	v x: x; y: y - h; z: 0; u: 0; v: 1.
+	v x: x; y: y - h; z: 0; u: 0; v: 1
 ]

--- a/src/SDL3-GPUDemos/SDL3GPURenderStateDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPURenderStateDemo.class.st
@@ -24,7 +24,7 @@ Class {
 SDL3GPURenderStateDemo >> close [
 
 	renderStates do: [ :each | each destroy ].
-	shaders do: [ :each | gpuDevice releaseGPUShader: each ].
+	shaders do: [ :each | each release ].
 
 	foregroundTexture destroy.
 	backgroundTexture destroy.
@@ -52,7 +52,7 @@ SDL3GPURenderStateDemo >> initialize [
 		SDL3CRTEffectShaderSource.
 		SDL3DotsHalftoneShaderSource.
 		SDL3HighlightShaderSource.
-		SDL3MoireShaderSource 
+		SDL3MoireShaderSource
 		}.
 
 	renderStateIndex := 1
@@ -65,12 +65,11 @@ SDL3GPURenderStateDemo >> initializeGPURenderStates [
 	supportedShaderFormats := gpuDevice gpuShaderFormatsAsArray.
 
 	shaderSources do: [ :eachSources |
-		| aShader renderStateInfo aRenderState |
+		| aShader aRenderState |
 		aShader := eachSources newShaderAmong: supportedShaderFormats device: gpuDevice.
 
-		renderStateInfo := SDL_GPURenderStateCreateInfo new.
-		renderStateInfo fragmentShader: aShader.
-		aRenderState := renderer newGPURenderStateCreateinfo: renderStateInfo.
+		aRenderState := renderer newRenderState: [ :info |
+			info fragmentShader: aShader ].
 
 		shaders add: aShader. "Keep a reference to destroy on close"
 		renderStates add: aRenderState "These will be switched with arrow keys" ].
@@ -109,9 +108,9 @@ SDL3GPURenderStateDemo >> open [
 			flags: self initialWindowFlags.
 
 	renderer := window newGPURenderer.
-	
+
 	window startTextInput.
-	
+
 	gpuDevice := renderer gpuDevice.
 
 	self
@@ -144,7 +143,7 @@ SDL3GPURenderStateDemo >> render [
 				origin: (backgroundTexture extent - foregroundTexture extent / 2)
 				extent: foregroundTexture extent).
 
-	"We're done with rendering this frame, so let's present it on the window"	
+	"We're done with rendering this frame, so let's present it on the window"
 	self present
 ]
 
@@ -165,9 +164,8 @@ SDL3GPURenderStateDemo >> updateRenderState: renderState [
 		resolutionY: backgroundTexture h.
 
 	renderState
-		fragmentUniformsSlotIndex: 0
-		data: uniformBuffer
-		length: uniformBuffer byteSize.
+		pushFragmentUniform: uniformBuffer
+		slot: 0.
 
 	renderer gpuRenderState: renderState
 ]
@@ -195,6 +193,6 @@ SDL3GPURenderStateDemo >> visitKeyboardDownEvent: aKeyboardDownEvent [
 		renderStateIndex := renderStateIndex - 1.
 		renderStateIndex < 1 ifTrue: [
 			renderStateIndex := renderStates size ] ].
-	
+
 	self updateTitle
 ]

--- a/src/SDL3-GPUDemos/SDL3GPUSDFRoundedRectDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUSDFRoundedRectDemo.class.st
@@ -30,33 +30,34 @@ Class {
 { #category : 'lifecycle' }
 SDL3GPUSDFRoundedRectDemo >> close [
 
-	gpuPipeline ifNotNil: [ 
-		gpuDevice releaseGPUGraphicsPipeline: gpuPipeline.
+	gpuPipeline ifNotNil: [
+		gpuPipeline release.
 		gpuPipeline := nil ].
 
-	vertexTransferBuffer ifNotNil: [ 
-		gpuDevice releaseGPUTransferBuffer: vertexTransferBuffer.
+	vertexTransferBuffer ifNotNil: [
+		vertexTransferBuffer release.
 		vertexTransferBuffer := nil ].
-	
-	indexTransferBuffer ifNotNil: [ 
-		gpuDevice releaseGPUTransferBuffer: indexTransferBuffer.
+
+	indexTransferBuffer ifNotNil: [
+		indexTransferBuffer release.
 		indexTransferBuffer := nil ].
 
-	vertexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: vertexBuffer.
+	vertexBuffer ifNotNil: [
+		vertexBuffer release.
 		vertexBuffer := nil ].
 
-	indexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: indexBuffer.
+	indexBuffer ifNotNil: [
+		indexBuffer release.
 		indexBuffer := nil ].
 
 	super close
 ]
 
 { #category : 'rendering' }
-SDL3GPUSDFRoundedRectDemo >> doRenderPassesOn: swapchainTexture with: aCommandBuffer [
+SDL3GPUSDFRoundedRectDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 
-	| renderPass quadWidthPixels quadHeightPixels physicalExtent |
+	| quadWidthPixels quadHeightPixels physicalExtent |
+
 	colorTargetInfos first texture: swapchainTexture.
 
 	"Calculate actual pixel dimensions of the quads based on window size and grid"
@@ -73,33 +74,20 @@ SDL3GPUSDFRoundedRectDemo >> doRenderPassesOn: swapchainTexture with: aCommandBu
 		cornerR4: cornerRadiiBase;
 		radius: radius.
 
-	aCommandBuffer
-		pushGPUFragmentUniformDataSlotIndex: 0
-		data: sdfUniforms
-		length: sdfUniforms class structureSize.
+	commandBuffer
+		pushFragmentUniform: sdfUniforms slot: 0.
 
-	renderPass :=
-		aCommandBuffer
-			beginGPURenderPassColorTargetInfos: colorTargetInfos
-			depthStencilTargetInfo: nil.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		renderPass
+			pipeline: gpuPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			indexBuffer16Bit: indexBinding;
+			drawIndexedPrimitives: self indicesCount
+			instances: 1
+			firstIndex: 0
+			vertexOffset: 0
+			firstInstance: 0 ]
 
-	renderPass bindGPUGraphicsPipeline: gpuPipeline.
-
-	renderPass
-		bindGPUVertexBuffersFirstSlot: 0
-		bindings: vertexBufferBindings.
-	renderPass
-		bindGPUIndexBufferBinding: indexBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-
-	renderPass
-		drawGPUIndexedPrimitivesNumIndices: self indicesCount
-		numInstances: 1
-		firstIndex: 0
-		vertexOffset: 0
-		firstInstance: 0.
-
-	renderPass end
 ]
 
 { #category : 'accessing' }
@@ -121,20 +109,13 @@ SDL3GPUSDFRoundedRectDemo >> initialize [
 	cornerRadiiBase := 20.0.
 	radius := 50.0.
 
-	colorTargetInfos := FFIExternalArray
-							externalNewType: SDL_GPUColorTargetInfo
-							size: 1.
-	colorTargetInfos autoRelease.
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR;
-		updateClearColorFrom: (Color r: 0.1 g: 0.1 b: 0.1).
+		beClear: (Color r: 0.1 g: 0.1 b: 0.1).
 
 	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
 
-	indexBinding := SDL_GPUBufferBinding externalNew.
-	indexBinding autoRelease.
-	indexBinding offset: 0.
+	indexBinding := SDL_GPUBufferBinding offset: 0.
 
 	sdfUniforms := SDL3GPUSDFRoundedRectUniforms new.
 	sdfUniforms
@@ -151,7 +132,8 @@ SDL3GPUSDFRoundedRectDemo >> initialize [
 { #category : 'initialization' }
 SDL3GPUSDFRoundedRectDemo >> initializePipeline [
 
-	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets pipelineCreateInfo |
+	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets |
+
 	vertexShader := SDL3GPUQuadVertexShaderSource
 						newShaderAmong: shaderFormats
 						device: gpuDevice.
@@ -162,49 +144,24 @@ SDL3GPUSDFRoundedRectDemo >> initializePipeline [
 	vertexBindings := self newSDFVertexBindings.
 	vertexAttributes := self newSDFVertexAttributes.
 
-	colorTargets := self newColorTargetDescriptions: 1.
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
 	colorTargets first
 		format: (gpuDevice getGPUSwapchainTextureFormatIntoWindow: window);
-		blendState: self newAlphaBlendState.
+		blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
 
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader;
-		fragmentShader: fragmentShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: colorTargets size.
-	pipelineCreateInfo vertexInputState
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: vertexBindings size;
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: vertexAttributes size.
-
-	gpuPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo:
-		              pipelineCreateInfo.
+	gpuPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
 	"We can free after pipeline was created"
-	gpuDevice releaseGPUShader: vertexShader.
+	vertexShader release.
 
-	gpuDevice releaseGPUShader: fragmentShader.
-	vertexBindings free.
-	vertexAttributes free.
-	colorTargets free
-]
-
-{ #category : 'private' }
-SDL3GPUSDFRoundedRectDemo >> newAlphaBlendState [
-
-	^ SDL_GPUColorTargetBlendState new
-		 enableBlend: true;
-		 srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-		 dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-		 colorBlendOp: SDL_GPU_BLENDOP_ADD;
-		 srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-		 dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-		 alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-		 yourself
+	fragmentShader release
 ]
 
 { #category : 'initialization' }
@@ -229,20 +186,20 @@ SDL3GPUSDFRoundedRectDemo >> newQuadIndices [
 SDL3GPUSDFRoundedRectDemo >> newSDFVertexAttributes [
 
 	| vertexAttributes |
-	vertexAttributes := FFIExternalArray
-							externalNewType: SDL_GPUVertexAttribute
-							size: 2.
-	vertexAttributes autoRelease.
+	vertexAttributes := SDL_GPUVertexAttribute safeNewArray: 2.
+
 	vertexAttributes first
 		bufferSlot: 0;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
 		location: 0;
 		offset: 0.
+
 	vertexAttributes second
 		bufferSlot: 0;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
 		location: 1;
 		offset: 12.
+
 	^ vertexAttributes
 ]
 
@@ -250,15 +207,14 @@ SDL3GPUSDFRoundedRectDemo >> newSDFVertexAttributes [
 SDL3GPUSDFRoundedRectDemo >> newSDFVertexBindings [
 
 	| vertexBindings |
-	vertexBindings := FFIExternalArray
-						 externalNewType: SDL_GPUVertexBufferDescription
-						 size: 1.
-	vertexBindings autoRelease.
+	vertexBindings := SDL_GPUVertexBufferDescription safeNewArray: 1.
+
 	vertexBindings first
 		slot: 0;
 		inputRate: SDL_GPU_VERTEXINPUTRATE_VERTEX;
 		instanceStepRate: 0;
 		pitch: SDL3GPUQuadVertex structureSize.
+
 	^ vertexBindings
 ]
 
@@ -288,133 +244,95 @@ SDL3GPUSDFRoundedRectDemo >> step [
 { #category : 'initialization' }
 SDL3GPUSDFRoundedRectDemo >> updateIndexBuffer [
 
-	| mappedAddress indices byteSize commandBuffer |
-	
+	| byteSize |
 	byteSize := self indicesCount * 2. "16-bit indices"
 
 	"1. Initialize buffer (or recreate if number of quads changed)"
 	indexBufferSize = byteSize ifFalse: [
-
 		indexBuffer ifNotNil: [
-			gpuDevice releaseGPUBuffer: indexBuffer.
-			gpuDevice releaseGPUTransferBuffer: indexTransferBuffer ].
+			indexBuffer release.
+			indexTransferBuffer release ].
 
 		indexTransferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
 
-		indexBuffer := gpuDevice 
-			newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
-			size: byteSize.
+		indexBuffer := gpuDevice
+			               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+			               size: byteSize.
 
 		indexBinding buffer: indexBuffer.
 		indexBufferSize := byteSize ].
 
 	"2. Upload new data"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: indexTransferBuffer cycle: true.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
-
-	indices := FFIArray fromHandle: mappedAddress type: FFIUInt16 size: self indicesCount.
-	
-	1 to: numberOfQuads do: [ :i |
-		| baseVertex baseIndex |
-		baseVertex := (i - 1) * self numberOfVerticesPerQuad.
-		baseIndex := (i - 1) * 6.
-		1 to: 6 do: [ :j |
-			indices at: baseIndex + j put: baseVertex + (self newQuadIndices at: j) ] ].
-
-	gpuDevice unmapGPUTransferBuffer: indexTransferBuffer.
-
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource:
-			(SDL_GPUTransferBufferLocation new
-				transferBuffer: indexTransferBuffer;
-				offset: 0;
-				yourself)
-		destination:
-			(SDL_GPUBufferRegion new
-				buffer: indexBuffer;
-				offset: 0;
-				size: byteSize;
-				yourself)
-		cycle: true;
-		end.
-	commandBuffer submit
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			transferBuffer: indexTransferBuffer
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: self indicesCount
+			cycle: true
+			fillWith: [ :indices |
+				1 to: numberOfQuads do: [ :i |
+					| baseVertex baseIndex |
+					baseVertex := (i - 1) * self numberOfVerticesPerQuad.
+					baseIndex := (i - 1) * 6.
+					1 to: 6 do: [ :j |
+						indices
+							at: baseIndex + j
+							put: baseVertex + (self newQuadIndices at: j) ] ] ] ]
 ]
 
 { #category : 'initialization' }
 SDL3GPUSDFRoundedRectDemo >> updateVertexBuffer [
 
-	| mappedAddress vertices byteSize commandBuffer quadW quadH padX padY cellW cellH |
-	
+	| byteSize cellW cellH padX padY quadW quadH |
 	cellW := 2.0 / columns.
 	cellH := 2.0 / rows.
-	
+
 	padX := cellW * 0.1.
 	padY := cellH * 0.1.
-	
+
 	quadW := cellW - padX.
 	quadH := cellH - padY.
-	
+
 	byteSize := SDL3GPUQuadVertex structureSize * self verticesCount.
 
 	"2. Initialize buffer (or recreate if number of quads changed)"
 	vertexBufferSize = byteSize ifFalse: [
-
 		vertexBuffer ifNotNil: [
-			gpuDevice releaseGPUBuffer: vertexBuffer.
-			gpuDevice releaseGPUTransferBuffer: vertexTransferBuffer ].
+			vertexBuffer release.
+			vertexTransferBuffer release ].
 
 		vertexTransferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
 
-		vertexBuffer := gpuDevice 
-			newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
-			size: byteSize.
+		vertexBuffer := gpuDevice
+			               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+			               size: byteSize.
 
 		vertexBufferBindings first buffer: vertexBuffer.
 		vertexBufferSize := byteSize ].
 
 	"3. Upload new data (Using CYCLE: TRUE for animation)"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: vertexTransferBuffer cycle: true.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
-
-	vertices :=
-		FFIArray
-			fromHandle: mappedAddress
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			transferBuffer: vertexTransferBuffer
+			uploadTo: vertexBuffer
 			type: SDL3GPUQuadVertex
-			size: self verticesCount.
-	
-	1 to: numberOfQuads do: [ :i |
-		| col row x y |
-		row := (i - 1) // columns + 1.
-		col := (i - 1) \\ columns + 1.
-		x := -1.0 + (padX * 0.5) + ((col - 1) * cellW).
-		y := 1.0 - (padY * 0.5) - ((row - 1) * cellH).
-		self
-			writeQuadTo: vertices
-			at: (i - 1) * self numberOfVerticesPerQuad + 1 
-			x: x
-			y: y
-			w: quadW
-			h: quadH ].
-
-	gpuDevice unmapGPUTransferBuffer: vertexTransferBuffer.
-
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource:
-			(SDL_GPUTransferBufferLocation new
-				transferBuffer: vertexTransferBuffer;
-				offset: 0;
-				yourself)
-		destination:
-			(SDL_GPUBufferRegion new
-				buffer: vertexBuffer;
-				offset: 0;
-				size: byteSize;
-				yourself)
-		cycle: true;
-		end.
-	commandBuffer submit
+			count: self verticesCount
+			cycle: true
+			fillWith: [ :vertices |
+				1 to: numberOfQuads do: [ :i |
+					| col row x y |
+					row := (i - 1) // columns + 1.
+					col := (i - 1) \\ columns + 1.
+					x := -1.0 + (padX * 0.5) + ((col - 1) * cellW).
+					y := 1.0 - (padY * 0.5) - ((row - 1) * cellH).
+					self
+						writeQuadTo: vertices
+						at: (i - 1) * self numberOfVerticesPerQuad + 1
+						x: x
+						y: y
+						w: quadW
+						h: quadH ] ] ]
 ]
 
 { #category : 'accessing' }
@@ -467,7 +385,7 @@ SDL3GPUSDFRoundedRectDemo >> writeQuadTo: aVertexArray at: startIndex x: x y: y 
 	| v |
 	"Vertices (NDC): y increases UPWARDS.
 	UVs: y increases DOWNWARDS.
-	
+
 	0: TL: x, y	   UV: 0, 0
 	1: TR: x+w, y	 UV: 1, 0
 	2: BR: x+w, y-h   UV: 1, 1
@@ -485,5 +403,5 @@ SDL3GPUSDFRoundedRectDemo >> writeQuadTo: aVertexArray at: startIndex x: x y: y 
 	v x: x + w; y: y - h; z: 0; u: 1; v: 1.
 	"3: BL"
 	v := aVertexArray at: startIndex + 3.
-	v x: x; y: y - h; z: 0; u: 0; v: 1.
+	v x: x; y: y - h; z: 0; u: 0; v: 1
 ]

--- a/src/SDL3-GPUDemos/SDL3GPUSDFRoundedRectFragmentShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUSDFRoundedRectFragmentShaderSource.class.st
@@ -77,7 +77,7 @@ float4 main(PSInput input) : SV_Target {
    float2 dimensions = float2(dimX, dimY);
    float4 cornerRadii = float4(cornerR1, cornerR2, cornerR3, cornerR4);
    float2 p = (input.uv - 0.5) * dimensions;
-   
+
    float d = 0.0;
    if (shapeType == 0) {
        // Circle: radius is clamped to min dimension / 2
@@ -92,19 +92,19 @@ float4 main(PSInput input) : SV_Target {
        f = min(f, dimensions.y / max(0.0001, r.w + r.z)); // Left Edge
        f = min(f, dimensions.y / max(0.0001, r.y + r.x)); // Right Edge
        r *= f;
-       
+
        d = sdRoundedBox(p, dimensions * 0.5, r);
    }
-   
+
    // Anti-aliasing using fwidth or smoothstep
    float aa = fwidth(d) * 0.7071;
-   
+
    // Inside the shape
    float shapeAlpha = 1.0 - smoothstep(-aa, aa, d);
-   
+
    // Stroke distance
    float strokeD = abs(d + strokeSize * 0.5) - strokeSize * 0.5;
-   
+
    // Dashed stroke logic
    float dashAlpha = 1.0;
    if (dashCount > 0.0) {
@@ -115,7 +115,7 @@ float4 main(PSInput input) : SV_Target {
            s = normalizedAngle * dashCount;
        } else {
            float2 b = dimensions * 0.5;
-           
+
            // Re-apply CSS-like scaling to get accurate centers
            float4 r = cornerRadii;
            float f = 1.0;
@@ -130,14 +130,14 @@ float4 main(PSInput input) : SV_Target {
            float2 cBR = float2( b.x - rBR,  b.y - rBR);
            float2 cBL = float2(-b.x + rBL,  b.y - rBL);
            float2 cTL = float2(-b.x + rTL, -b.y + rTL);
-           
+
            float pTop = cTR.x - cTL.x;       float pTR = (PI / 2.0) * rTR;
            float pRight = cBR.y - cTR.y;     float pBR = (PI / 2.0) * rBR;
            float pBottom = cBR.x - cBL.x;    float pBL = (PI / 2.0) * rBL;
            float pLeft = cBL.y - cTL.y;      float pTL = (PI / 2.0) * rTL;
-           
+
            float perimeter = pTop + pTR + pRight + pBR + pBottom + pBL + pLeft + pTL;
-           
+
            if (p.x > cTR.x && p.y < cTR.y) {
                float angle = atan2(p.x - cTR.x, -(p.y - cTR.y));
                s = pTop + angle * rTR;
@@ -155,7 +155,7 @@ float4 main(PSInput input) : SV_Target {
                float dBottom = abs(p.y - b.y);
                float dLeft = abs(p.x - (-b.x));
                float dRight = abs(p.x - b.x);
-               
+
                if (dTop <= dBottom && dTop <= dLeft && dTop <= dRight) {
                    s = p.x - cTL.x;
                } else if (dRight <= dBottom && dRight <= dLeft) {
@@ -171,9 +171,9 @@ float4 main(PSInput input) : SV_Target {
        float dashPattern = fmod(s, 2.0);
        dashAlpha = dashPattern < 1.0 ? 1.0 : 0.0;
    }
-   
+
    float strokeAlpha = (1.0 - smoothstep(-aa, aa, strokeD)) * dashAlpha;
-   
+
    // Gradient fill logic
    float4 currentFillColor = fillColor;
    if (fillType == 1) { // Linear gradient (vertical)
@@ -182,13 +182,13 @@ float4 main(PSInput input) : SV_Target {
        float distFromCenter = length(input.uv - 0.5) * 2.0; // 0 at center, 1 at edge
        currentFillColor = lerp(fillColor, fillColor2, clamp(distFromCenter, 0.0, 1.0));
    }
-   
+
    // Combine fill and stroke
    float4 finalColor = lerp(float4(currentFillColor.rgb, 0.0), currentFillColor, shapeAlpha);
    if (strokeSize > 0.0) {
        finalColor = lerp(finalColor, strokeColor, strokeAlpha);
    }
-   
+
    return finalColor;
 }
 '

--- a/src/SDL3-GPUDemos/SDL3GPUShimmerDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUShimmerDemo.class.st
@@ -29,19 +29,19 @@ Class {
 SDL3GPUShimmerDemo >> close [
 
 	gpuPipeline ifNotNil: [
-		gpuDevice releaseGPUGraphicsPipeline: gpuPipeline.
+		gpuPipeline release.
 		gpuPipeline := nil ].
 
 	vertexBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: vertexBuffer.
+		vertexBuffer release.
 		vertexBuffer := nil ].
-		
+
 	instanceBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: instanceBuffer.
+		instanceBuffer release.
 		instanceBuffer := nil ].
 
 	indexBuffer ifNotNil: [
-		gpuDevice releaseGPUBuffer: indexBuffer.
+		indexBuffer release.
 		indexBuffer := nil ].
 
 	super close
@@ -50,33 +50,21 @@ SDL3GPUShimmerDemo >> close [
 { #category : 'rendering' }
 SDL3GPUShimmerDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 
-	| renderPass |
 	colorTargetInfos first texture: swapchainTextureHolder value.
 
-	renderPass := commandBuffer
-					 beginGPURenderPassColorTargetInfos: colorTargetInfos
-					 depthStencilTargetInfo: nil.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		renderPass
+			pipeline: gpuPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			indexBuffer16Bit: indexBufferBinding.
 
-	renderPass bindGPUGraphicsPipeline: gpuPipeline.
-	renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings.
-	renderPass bindGPUIndexBufferBinding: indexBufferBinding indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-	
-	"Push Fragment Uniforms (space3 corresponds to Fragment stage per ground truth)"
-	commandBuffer 
-		pushGPUFragmentUniformDataSlotIndex: 0 
-		data: uniforms
-		length: SDL3GPUShimmerUniforms structureSize.
+		"Push Fragment Uniforms (space3 corresponds to Fragment stage per ground truth)"
+		commandBuffer
+			pushFragmentUniform: uniforms slot: 0;
+			pushVertexUniform: uniforms slot: 0.
 
-	"Push Vertex Uniforms (space1 corresponds to Vertex stage)"
-	commandBuffer 
-		pushGPUVertexUniformDataSlotIndex: 0 
-		data: uniforms
-		length: SDL3GPUShimmerUniforms structureSize.
-
-	"Draw 1 quad (6 indices) per instance"
-	renderPass drawGPUIndexedPrimitivesNumIndices: 6 numInstances: numberOfInstances firstIndex: 0 vertexOffset: 0 firstInstance: 0.
-
-	renderPass end
+		"Draw 1 quad (6 indices) per instance"
+		renderPass drawIndexedPrimitives: 6 instances: numberOfInstances firstIndex: 0 vertexOffset: 0 firstInstance: 0 ]
 ]
 
 { #category : 'initialization' }
@@ -88,17 +76,13 @@ SDL3GPUShimmerDemo >> initialize [
 
 	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 2.
 
-	instanceBufferBinding := FFIExternalArray externalNewType: SDL_GPUBufferBinding size: 1.
-	instanceBufferBinding autoRelease.
+	instanceBufferBinding := SDL_GPUBufferBinding safeNewArray: 1.
 
-	colorTargetInfos := FFIArray newType: SDL_GPUColorTargetInfo size: 1.
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR.
-	colorTargetInfos first clearColor updateFrom: (Color r: 0.05 g: 0.05 b: 0.1). "Dark theme"
+		beClear: (Color r: 0.05 g: 0.05 b: 0.1). "Dark background"
 
-	uniforms := SDL3GPUShimmerUniforms externalNew.
-	uniforms autoRelease.
+	uniforms := SDL3GPUShimmerUniforms safeNew.
 	uniforms
 		effectType: effectType;
 		time: 0.0;
@@ -119,94 +103,151 @@ SDL3GPUShimmerDemo >> initializeGeometry [
 { #category : 'initialization' }
 SDL3GPUShimmerDemo >> initializePipeline [
 
-	| vertexShader fragmentShader shaderFormats vertexAttributes vertexBindings pipelineCreateInfo colorTargets |
+	| vertexShader fragmentShader shaderFormats vertexAttributes vertexBindings colorTargets |
+
 	shaderFormats := gpuDevice gpuShaderFormatsAsArray.
 
 	vertexShader := SDL3GPUShimmerVertexShaderSource newShaderAmong: shaderFormats device: gpuDevice.
 	fragmentShader := SDL3GPUShimmerFragmentShaderSource newShaderAmong: shaderFormats device: gpuDevice.
 
-	vertexBindings := FFIExternalArray externalNewType: SDL_GPUVertexBufferDescription size: 2.
-	vertexBindings autoRelease.
-	
+	vertexBindings := SDL_GPUVertexBufferDescription safeNewArray: 2.
+
 	"Binding 0: Quad vertices (per vertex)"
-	(vertexBindings at: 1)
+	vertexBindings first
 		slot: 0;
 		pitch: SDL3GPUQuadVertex structureSize;
 		inputRate: SDL_GPU_VERTEXINPUTRATE_VERTEX;
 		instanceStepRate: 0.
-		
+
 	"Binding 1: Instance Data (per instance)"
-	(vertexBindings at: 2)
+	vertexBindings second
 		slot: 1;
 		pitch: SDL3GPUShimmerInstance structureSize;
 		inputRate: SDL_GPU_VERTEXINPUTRATE_INSTANCE;
 		instanceStepRate: 0.
 
-	vertexAttributes := FFIExternalArray externalNewType: SDL_GPUVertexAttribute size: 4.
-	vertexAttributes autoRelease.
+	vertexAttributes := SDL_GPUVertexAttribute safeNewArray: 4.
 
 	"Quad Position (Attribute 0)"
-	(vertexAttributes at: 1)
+	vertexAttributes first
 		bufferSlot: 0;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
 		location: 0;
 		offset: 0.
-		
+
 	"Quad TexCoord (Attribute 1)"
-	(vertexAttributes at: 2)
+	vertexAttributes second
 		bufferSlot: 0;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
 		location: 1;
 		offset: 3 * FFIFloat32 externalTypeSize.
-		
+
 	"Instance Bounds (Attribute 2)"
-	(vertexAttributes at: 3)
+	vertexAttributes third
 		bufferSlot: 1;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4;
 		location: 2;
 		offset: 0.
 
 	"Instance Extra/Radius (Attribute 3)"
-	(vertexAttributes at: 4)
+	vertexAttributes fourth
 		bufferSlot: 1;
 		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4;
 		location: 3;
 		offset: 16.
 
-	colorTargets := FFIExternalArray externalNewType: SDL_GPUColorTargetDescription size: 1.
-	colorTargets autoRelease.
-	colorTargets first 
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
+	colorTargets first
 		format: (gpuDevice getGPUSwapchainTextureFormatIntoWindow: window);
-		blendState: (SDL_GPUColorTargetBlendState new
-			enableBlend: true;
-			srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-			dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-			colorBlendOp: SDL_GPU_BLENDOP_ADD;
-			srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-			dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ZERO;
-			alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-			yourself).
+		blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
 
-	pipelineCreateInfo := SDL3GPUGraphicsPipelineCreateInfo externalNew.
-	pipelineCreateInfo autoRelease.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader;
-		fragmentShader: fragmentShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: 1;
-		hasDepthStencilTarget: false.
-	pipelineCreateInfo vertexInputState
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: 4;
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: 2.
+	gpuPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
-	gpuPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
+	vertexShader release.
+	fragmentShader release
+]
 
-	gpuDevice releaseGPUShader: vertexShader.
-	gpuDevice releaseGPUShader: fragmentShader.
+{ #category : 'initialization' }
+SDL3GPUShimmerDemo >> initializeQuadBuffers: instances [
+
+	vertexBuffer := gpuDevice
+		                newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                size: 4 * SDL3GPUQuadVertex structureSize.
+
+	indexBuffer := gpuDevice
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+		               size: 6 * 2.
+
+	instanceBuffer := gpuDevice
+		                  newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                  size: instances size * SDL3GPUShimmerInstance structureSize.
+
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: vertexBuffer
+			type: SDL3GPUQuadVertex
+			count: 4
+			cycle: false
+			fillWith: [ :vertices |
+				vertices first
+					x: 0.0;
+					y: 0.0;
+					z: 0.0;
+					u: 0.0;
+					v: 0.0.
+				vertices second
+					x: 1.0;
+					y: 0.0;
+					z: 0.0;
+					u: 1.0;
+					v: 0.0.
+				vertices third
+					x: 1.0;
+					y: 1.0;
+					z: 0.0;
+					u: 1.0;
+					v: 1.0.
+				vertices fourth
+					x: 0.0;
+					y: 1.0;
+					z: 0.0;
+					u: 0.0;
+					v: 1.0 ].
+
+		uploader
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: 6
+			cycle: false
+			fillWith: [ :indices |
+				indices
+					at: 1 put: 0;
+					at: 2 put: 1;
+					at: 3 put: 2;
+					at: 4 put: 0;
+					at: 5 put: 2;
+					at: 6 put: 3 ].
+
+		uploader
+			uploadTo: instanceBuffer
+			type: SDL3GPUShimmerInstance
+			count: instances size
+			cycle: false
+			fillWith: [ :mappedInstances |
+				instances withIndexDo: [ :inst :idx |
+					(mappedInstances at: idx)
+						x: inst x;
+						y: inst y;
+						w: inst w;
+						h: inst h;
+						radius: inst radius ] ] ]
 ]
 
 { #category : 'initialization' }
@@ -214,7 +255,7 @@ SDL3GPUShimmerDemo >> mockUIPanels [
 	"Create a social network feed loading state."
 	| panels |
 	panels := OrderedCollection new.
-	
+
 	"Post 1"
 	"Avatar (Circle)"
 	panels add: (SDL3GPUShimmerInstance new x: 40/1280.0; y: 40/720.0; w: 60/1280.0; h: 60/720.0; radius: 30.0).
@@ -239,10 +280,25 @@ SDL3GPUShimmerDemo >> open [
 	self initializePipeline
 ]
 
+{ #category : 'initialization' }
+SDL3GPUShimmerDemo >> setupGeometryBindings [
+
+	vertexBufferBindings first
+		buffer: vertexBuffer;
+		offset: 0.
+	vertexBufferBindings second
+		buffer: instanceBuffer;
+		offset: 0.
+
+	indexBufferBinding := SDL_GPUBufferBinding
+		                      buffer: indexBuffer
+		                      offset: 0
+]
+
 { #category : 'hooks' }
 SDL3GPUShimmerDemo >> step [
 
-	uniforms 
+	uniforms
 		time: Time millisecondClockValue / 1000.0;
 		resolutionX: (window extent x max: 1) asFloat;
 		resolutionY: (window extent y max: 1) asFloat.
@@ -265,106 +321,16 @@ SDL3GPUShimmerDemo >> updatedTitle [
 SDL3GPUShimmerDemo >> uploadGeometry: instances [
 	"Upload quad vertices, indices, and instance data (panels)."
 
-	| vertices indices vTransfer iTransfer instTransfer mappedAddress vSize iSize instSize copyCommandBuffer mappedInstances |
-
-	"1. Quad Vertices (Standard 1x1 quad)"
-	vSize := 4 * SDL3GPUQuadVertex structureSize.
-	vertexBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX size: vSize.
-	vTransfer := gpuDevice newUploadTransferBuffer: vSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: vTransfer cycle: false.
-	
-	vertices := FFIArray fromHandle: mappedAddress type: SDL3GPUQuadVertex size: 4.
-	(vertices at: 1) x: 0.0; y: 0.0; z: 0.0; u: 0.0; v: 0.0.
-	(vertices at: 2) x: 1.0; y: 0.0; z: 0.0; u: 1.0; v: 0.0.
-	(vertices at: 3) x: 1.0; y: 1.0; z: 0.0; u: 1.0; v: 1.0.
-	(vertices at: 4) x: 0.0; y: 1.0; z: 0.0; u: 0.0; v: 1.0.
-	
-	gpuDevice unmapGPUTransferBuffer: vTransfer.
-
-	"2. Quad Indices"
-	iSize := 6 * 2. "16-bit indices"
-	indexBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX size: iSize.
-	iTransfer := gpuDevice newUploadTransferBuffer: iSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: iTransfer cycle: false.
-	
-	indices := FFIArray fromHandle: mappedAddress type: FFIUInt16 size: 6.
-	indices at: 1 put: 0. indices at: 2 put: 1. indices at: 3 put: 2.
-	indices at: 4 put: 0. indices at: 5 put: 2. indices at: 6 put: 3.
-	
-	gpuDevice unmapGPUTransferBuffer: iTransfer.
-
-	"3. Instance Data (Social Network Layout)"
-	instSize := instances size * SDL3GPUShimmerInstance structureSize.
-	instanceBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX size: instSize.
-	instTransfer := gpuDevice newUploadTransferBuffer: instSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: instTransfer cycle: false.
-	
-	mappedInstances := FFIArray fromHandle: mappedAddress type: SDL3GPUShimmerInstance size: instances size.
-	instances withIndexDo: [ :inst :idx |
-		(mappedInstances at: idx)
-			x: inst x;
-			y: inst y;
-			w: inst w;
-			h: inst h;
-			radius: inst radius.
-	].
-	gpuDevice unmapGPUTransferBuffer: instTransfer.
-
-	"Upload"
-	copyCommandBuffer := gpuDevice acquireGPUCommandBuffer.
-	[ :copyPass |
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: vTransfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: vertexBuffer;
-					offset: 0;
-					size: vSize;
-					yourself)
-			cycle: false.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: iTransfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: indexBuffer;
-					offset: 0;
-					size: iSize;
-					yourself)
-			cycle: false.
-		copyPass
-			uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-					transferBuffer: instTransfer;
-					offset: 0;
-					yourself)
-			destination: (SDL_GPUBufferRegion new
-					buffer: instanceBuffer;
-					offset: 0;
-					size: instSize;
-					yourself)
-			cycle: false.
-		copyPass end ] value: copyCommandBuffer beginGPUCopyPass.
-	copyCommandBuffer submit.
-
-	gpuDevice releaseGPUTransferBuffer: vTransfer.
-	gpuDevice releaseGPUTransferBuffer: iTransfer.
-	gpuDevice releaseGPUTransferBuffer: instTransfer.
-
-	vertexBufferBindings first buffer: vertexBuffer; offset: 0.
-	vertexBufferBindings second buffer: instanceBuffer; offset: 0.
-	
-	indexBufferBinding := SDL_GPUBufferBinding externalNew buffer: indexBuffer; offset: 0; yourself.
-	indexBufferBinding autoRelease.
+	self
+		initializeQuadBuffers: instances;
+		setupGeometryBindings
 ]
 
 { #category : 'hooks' }
 SDL3GPUShimmerDemo >> visitKeyboardDownEvent: aKeyboardDownEvent [
 
 	super visitKeyboardDownEvent: aKeyboardDownEvent.
-	
+
 	aKeyboardDownEvent key = SDLK_RIGHT asInteger ifTrue: [
 		effectType := (effectType + 1) \\ 3.
 		uniforms effectType: effectType ].

--- a/src/SDL3-GPUDemos/SDL3GPUShimmerFragmentShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUShimmerFragmentShaderSource.class.st
@@ -62,57 +62,57 @@ float4 main(FragmentInput input) : SV_Target {
    // p is the coordinate relative to the center of the panel
    float2 p = (input.TexCoord - 0.5) * input.PanelSize;
    float2 halfSize = input.PanelSize * 0.5;
-   float radius = input.Radius; 
-   
+   float radius = input.Radius;
+
    // Ensure radius doesn''t exceed half-dimensions
    radius = min(radius, min(halfSize.x, halfSize.y));
-   
+
    float dist = roundedRectSDF(p, halfSize, radius);
-   
+
    // Antialiased clipping: 0 outside, 1 inside
    // Use fwidth for smooth edges across different zoom/resolutions
    float edgeSoftness = fwidth(dist);
    float alpha = 1.0 - smoothstep(-edgeSoftness, edgeSoftness, dist);
-   
+
    // Early discard if completely outside for performance
    if (alpha <= 0.0) discard;
 
    float shimmer = 0.0;
-   
+
    if (effectType == 0) {
        // 0: Linear Sweep (left to right) - LOCAL COORDINATES
        float normalizedX = input.TexCoord.x;
-       
+
        // Create a sweeping wave based on time
        float wavePosition = frac(time * 0.5) * 2.0 - 0.5;
-       
+
        // Calculate distance from the wave front
        float dist = abs(normalizedX - wavePosition);
-       
+
        // Create a soft gradient peak
        shimmer = smoothstep(0.2, 0.0, dist);
-       
+
    } else if (effectType == 1) {
        // 1: Pulsate
        // Sine wave oscillating between 0.0 and 1.0
        shimmer = (sin(time * 3.0) * 0.5) + 0.5;
-       
+
    } else if (effectType == 2) {
        // 2: Angled Sweep - SCREEN COORDINATES
        // Combine X and Y for a diagonal effect
        float2 normalizedCoord = input.ScreenCoord / float2(resolutionX, resolutionY);
        float angledCoord = (normalizedCoord.x + normalizedCoord.y) * 0.5;
-       
+
        float wavePosition = frac(time * 0.5) * 2.0 - 0.5;
        float dist = abs(angledCoord - wavePosition);
-       
+
        shimmer = smoothstep(0.3, 0.0, dist);
    }
-   
+
    // Blend base and highlight colors based on the shimmer intensity
    float4 finalColor = lerp(baseColor, highlightColor, shimmer);
    finalColor.a *= alpha;
-   
+
    return finalColor;
 }
 '

--- a/src/SDL3-GPUDemos/SDL3GPUShimmerVertexShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUShimmerVertexShaderSource.class.st
@@ -69,18 +69,18 @@ VertexOutput main(VertexInput vIn, InstanceInput iIn) {
 
    // Convert from 0..1 space to clip space (-1..1)
    float2 clipPos = normPos * 2.0 - 1.0;
-   
+
    vOut.Position = float4(clipPos, 0.5, 1.0);
    vOut.TexCoord = vIn.TexCoord;
-   
+
    // Calculate actual pixel dimensions for the fragment stage SDF
    vOut.PanelSize = iIn.Bounds.zw * float2(resolutionX, resolutionY);
-   
+
    // ScreenCoord for global effects
-   vOut.ScreenCoord = normPos * float2(resolutionX, resolutionY); 
-   
+   vOut.ScreenCoord = normPos * float2(resolutionX, resolutionY);
+
    vOut.Radius = iIn.Extra.x;
-   
+
    return vOut;
 }
 '

--- a/src/SDL3-GPUDemos/SDL3GPUTiledMapVertexShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3GPUTiledMapVertexShaderSource.class.st
@@ -55,13 +55,13 @@ VertexOutput main(VertexInput vIn, InstanceInput iIn) {
    // Position in NDC
    float2 pos = (vIn.Position.xy * iIn.ScreenRect.zw) + iIn.ScreenRect.xy;
    vOut.Position = float4(pos * 2.0 - 1.0, 0.5, 1.0);
-   
+
    // Map local quad UV (0..1) to Atlas region UV
    // Shrink by half-texel to avoid bleeding from neighboring slots
    // 4096.0 assumes an 8x8 grid of 512x512 tiles.
    float2 halfTexel = 0.5 / 4096.0;
    vOut.TexCoord = (vIn.TexCoord * (iIn.AtlasRect.zw - 2.0 * halfTexel)) + iIn.AtlasRect.xy + halfTexel;
-   
+
    return vOut;
 }
 '

--- a/src/SDL3-GPUDemos/SDL3HighlightShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3HighlightShaderSource.class.st
@@ -70,13 +70,13 @@ float4 main(PSInput input) : SV_Target
 {
    float4 input_color = InputTexture.Sample(InputSampler, input.uv) * input.color;
    float width = 0.001 * frequency * highlight_width / 2.0;
-	
+
 	// can play with + or - sign for each UV
 	// to control which direction the highlight moves
 	// ex. -UV.x - UV.y makes the highlight go from
 	// top left to bottom right
    float value = floor(sin(frequency * ((input.uv.x - input.uv.y) + time * highlight_speed)) + width);
-	
+
 	// used to control when to use input color vs highlight color
    float highlight = value > 0.5 ? 1.0 : 0.0;
    float3 new_color = input_color.rgb * (1.0 - highlight) + highlight_color.rgb * highlight;

--- a/src/SDL3-GPUDemos/SDL3MoireShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3MoireShaderSource.class.st
@@ -47,7 +47,7 @@ cbuffer Params : register(b0, space3)
 // Random function dependent on time
 float rand(float2 co, float time)
 {
-   return frac(sin(dot(co.xy, float2(92.0, 80.0))) + 
+   return frac(sin(dot(co.xy, float2(92.0, 80.0))) +
                cos(dot(co.xy, float2(cos(time) * 41.0, 62.0))) * 2.1);
 }
 
@@ -61,18 +61,18 @@ float4 main(PSInput input) : SV_Target
 {
    // Amount of jitter
    float amt = cos(time * 5.0) * 0.01;
-   
+
    // Base UV
    float2 uv = input.uv;
-   
+
    // Calculate random offset
-   // Note: The original code calls rand twice with the exact same UVs, 
+   // Note: The original code calls rand twice with the exact same UVs,
    // resulting in a diagonal offset (x == y). Replicated here for accuracy.
    float2 rnd = float2(rand(uv, time), rand(uv, time));
-   
+
    // Sample texture with offset
    float4 color = InputTexture.Sample(InputSampler, uv + rnd * amt);
-   
+
    return color * input.color;
 }
 '

--- a/src/SDL3-GPUDemos/SDL3NoiseShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3NoiseShaderSource.class.st
@@ -40,7 +40,7 @@ SamplerState InputSampler : register(s0, space2);
 
 cbuffer Params : register(b0, space3)
 {
-   float time;        
+   float time;
    float2 resolution;
 }
 
@@ -60,14 +60,14 @@ struct PSInput
 float4 main(PSInput input) : SV_Target
 {
    float2 texelSize = 1.0 / resolution;
-   
+
    // Generate noise
    float noise = rand(input.uv * resolution + time);
-   
+
    // Distort UVs
    float offsetMagnitude = (noise * 2.0 - 1.0);
    float2 offset = float2(offsetMagnitude, offsetMagnitude) * Strength * texelSize;
-   
+
    // Sample texture with offset
    return InputTexture.Sample(InputSampler, input.uv + offset) * input.color;
 }

--- a/src/SDL3-GPUDemos/SDL3RainShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3RainShaderSource.class.st
@@ -97,37 +97,37 @@ float4 main(PSInput input) : SV_Target
            #else
            float2 hsh = pi;
            #endif
-           
+
            float2 p = pi + hash22(hsh);
 
            float t = frac(0.3 * time + hash12(hsh));
            float2 v = p - uv;
-           
+
            float d = length(v) - (float(MAX_RADIUS) + 1.0) * t;
 
            float h = 1e-3;
            float d1 = d - h;
            float d2 = d + h;
-           
+
            float p1 = sin(31.0 * d1) * smoothstep(-0.6, -0.3, d1) * smoothstep(0.0, -0.3, d1);
            float p2 = sin(31.0 * d2) * smoothstep(-0.6, -0.3, d2) * smoothstep(0.0, -0.3, d2);
-           
+
            circles += 0.5 * normalize(v) * ((p2 - p1) / (2.0 * h) * (1.0 - t) * (1.0 - t));
        }
    }
-   
+
    circles /= float((MAX_RADIUS * 2 + 1) * (MAX_RADIUS * 2 + 1));
 
    float intensity = lerp(0.01, 0.15, smoothstep(0.1, 0.6, abs(frac(0.05 * time + 0.5) * 2.0 - 1.0)));
-   
+
    // Reconstruct Normal Z
    // Added max(0, ...) to prevent NaN if dot product slightly exceeds 1.0 due to float precision
    float3 n = float3(circles, sqrt(max(0.0, 1.0 - dot(circles, circles))));
-   
+
    // Color and Lighting
    float3 lightDir = normalize(float3(1.0, 0.7, 0.5));
    float specular = 5.0 * pow(clamp(dot(n, lightDir), 0.0, 1.0), 6.0);
-   
+
    // Texture Sample with offset
    // Base on input.uv (true [0,1]x[0,1] space) and scale the
    // ripple offset back from rain-space to UV space.

--- a/src/SDL3-GPUDemos/SDL3TextAtlasGenerator.class.st
+++ b/src/SDL3-GPUDemos/SDL3TextAtlasGenerator.class.st
@@ -69,15 +69,15 @@ SDL3TextAtlasGenerator >> generateAtlasFor: aCollectionOfCharacters deviceScale:
 
 		aCollectionOfCharacters do: [ :char | | charWidth |
 			charWidth := (font widthOfString: char asString) ceiling.
-			canvas pathTransform 
+			canvas pathTransform
 				loadIdentity;
 				translateX: currentX Y: font getPreciseAscent.
 			canvas drawString: char asString.
 
-			glyphMap at: char put: (Rectangle 
-				left: (currentX * deviceScale x) 
-				right: ((currentX + charWidth) * deviceScale x) 
-				top: 0 
+			glyphMap at: char put: (Rectangle
+				left: (currentX * deviceScale x)
+				right: ((currentX + charWidth) * deviceScale x)
+				top: 0
 				bottom: (font height ceiling * deviceScale y)).
 			currentX := currentX + charWidth + padding.
 		].

--- a/src/SDL3-GPUDemos/SDL3TextAtlasGeneratorTest.class.st
+++ b/src/SDL3-GPUDemos/SDL3TextAtlasGeneratorTest.class.st
@@ -1,0 +1,47 @@
+"
+Tests for SDL3TextAtlasGenerator.
+"
+Class {
+	#name : 'SDL3TextAtlasGeneratorTest',
+	#superclass : 'TestCase',
+	#category : 'SDL3-GPUDemos-TextScroll',
+	#package : 'SDL3-GPUDemos',
+	#tag : 'TextScroll'
+}
+
+{ #category : 'tests' }
+SDL3TextAtlasGeneratorTest >> testGenerateA8Atlas [
+	| generator atlas expectedSize |
+	generator := SDL3TextAtlasGenerator new.
+
+	atlas := generator generateAtlasFor: 'A' deviceScale: 1@1.
+
+	"For A8, we expect width * height bytes (plus potentially some stride padding, but AthensCairoSurface hides that mostly or we can check the stride if we had access to it).
+	Actually, let's just verify it's NOT 4 bytes per pixel."
+
+	self assert: atlas width > 0.
+	self assert: atlas height > 0.
+
+	"If it were ARGB32, it would be width * height * 4.
+	We can check the surface format if we add it to SDL3TextAtlas or just check the surface directly if possible."
+	self assert: atlas surface status equals: 0. "CAIRO_STATUS_SUCCESS"
+]
+
+{ #category : 'tests' }
+SDL3TextAtlasGeneratorTest >> testGenerateAtlasForString [
+	| generator atlas |
+	generator := SDL3TextAtlasGenerator new.
+	generator fontSize: 20.
+	generator familyName: 'Source Sans Pro'.
+
+	atlas := generator generateAtlasFor: 'Hello'.
+
+	self assert: atlas isNotNil.
+	self assert: atlas width > 0.
+	self assert: atlas height >= generator fontSize.
+	self assert: atlas dataPtr isNotNil.
+	self assert: (atlas glyphMap includesKey: $H).
+	self assert: (atlas glyphMap includesKey: $e).
+	self assert: (atlas glyphMap includesKey: $l).
+	self assert: (atlas glyphMap includesKey: $o)
+]

--- a/src/SDL3-GPUDemos/SDL3TextLayoutEngine.class.st
+++ b/src/SDL3-GPUDemos/SDL3TextLayoutEngine.class.st
@@ -66,22 +66,22 @@ SDL3TextLayoutEngine >> colorIndicesFor: char inComment: isComment isHeader: isH
 	5: Light Gray (Highlight BG)
 	"
 	bg := 4. "Default transparent"
-	
-	char = $! ifTrue: [ 
+
+	char = $! ifTrue: [
 		bg := 5. "Highlight the ! separator background"
-		^ 3 | (bg << 16) 
+		^ 3 | (bg << 16)
 	].
 
 	isComment ifTrue: [ ^ 1 | (bg << 16) ].
-	
-	isHeader ifTrue: [ 
+
+	isHeader ifTrue: [
 		(':.[ ]()' includes: char) ifTrue: [ ^ 2 | (bg << 16) ].
 		^ 0 | (bg << 16)
 	].
 
 	char isDigit ifTrue: [ ^ 2 | (bg << 16) ].
 	(':.[ ]()' includes: char) ifTrue: [ ^ 3 | (bg << 16) ].
-	
+
 	^ 0 | (bg << 16)
 ]
 
@@ -92,9 +92,9 @@ SDL3TextLayoutEngine >> layoutLine: lineIdx text: aString into: aBuffer glyphCou
 	state := lineStates at: lineIdx.
 	inComment := state first.
 	isHeader := state second.
-	
+
 	endIdx := (lineIdx < lineStarts size) ifTrue: [ (lineStarts at: lineIdx + 1) - 1 ] ifFalse: [ aString size ].
-	
+
 	currentX := 0.
 	currentY := (lineIdx - 1) * lineHeight.
 	glyphCount := startCount.
@@ -103,7 +103,7 @@ SDL3TextLayoutEngine >> layoutLine: lineIdx text: aString into: aBuffer glyphCou
 
 	startIdx to: endIdx do: [ :i | | char |
 		char := aString at: i.
-		
+
 		"Handle Syntax State"
 		char = $" ifTrue: [ inComment := inComment not ].
 
@@ -115,12 +115,12 @@ SDL3TextLayoutEngine >> layoutLine: lineIdx text: aString into: aBuffer glyphCou
 					currentX := currentX + tabWidth.
 				] ifFalse: [ | glyphBounds |
 					glyphBounds := atlas glyphMap at: char ifAbsent: [ nil ].
-					glyphBounds ifNotNil: [ 
+					glyphBounds ifNotNil: [
 						glyphCount := glyphCount + 1.
-						glyphCount <= aBuffer size ifTrue: [ 
-							self writeGlyph: glyphBounds 
-								at: currentX @ currentY 
-								uvScale: atlasWidth @ atlasHeight 
+						glyphCount <= aBuffer size ifTrue: [
+							self writeGlyph: glyphBounds
+								at: currentX @ currentY
+								uvScale: atlasWidth @ atlasHeight
 								colors: (self colorIndicesFor: char inComment: inComment isHeader: isHeader)
 								into: (aBuffer at: glyphCount)
 						].
@@ -130,7 +130,7 @@ SDL3TextLayoutEngine >> layoutLine: lineIdx text: aString into: aBuffer glyphCou
 			].
 		].
 	].
-	
+
 	^ glyphCount
 ]
 
@@ -140,14 +140,14 @@ SDL3TextLayoutEngine >> layoutString: aString [
 	lineStarts := OrderedCollection new.
 	lineStates := OrderedCollection new.
 	lineStarts add: 1.
-	
+
 	inComment := false.
 	isHeader := aString isNotEmpty and: [ (aString at: 1) = $! ].
 	lineStates add: { inComment . isHeader }.
 
 	aString doWithIndex: [ :char :i |
 		char = $" ifTrue: [ inComment := inComment not ].
-		char = Character cr ifTrue: [ 
+		char = Character cr ifTrue: [
 			| nextIsHeader |
 			lineStarts add: i + 1.
 			nextIsHeader := false.
@@ -199,16 +199,15 @@ SDL3TextLayoutEngine >> visibleLineRangeIn: aViewport [
 
 { #category : 'private' }
 SDL3TextLayoutEngine >> writeGlyph: bounds at: pos uvScale: uvScale colors: packedIndices into: struct [
-	"Use direct 1-based byte offsets to avoid class variable offset issues"
-	| h |
-	h := struct getHandle.
-	h floatAt: 1 put: pos x asFloat.
-	h floatAt: 5 put: pos y asFloat.
-	h floatAt: 9 put: bounds width asFloat.
-	h floatAt: 13 put: bounds height asFloat.
-	h floatAt: 17 put: bounds left asFloat / uvScale x.
-	h floatAt: 21 put: bounds top asFloat / uvScale y.
-	h floatAt: 25 put: bounds width asFloat / uvScale x.
-	h floatAt: 29 put: bounds height asFloat / uvScale y.
-	h unsignedLongAt: 33 put: packedIndices.
+
+	struct
+		posX: pos x asFloat;
+		posY: pos y asFloat;
+		extentX: bounds width asFloat;
+		extentY: bounds height asFloat;
+		uvX: bounds left asFloat / uvScale x;
+		uvY: bounds top asFloat / uvScale y;
+		uvWidth: bounds width asFloat / uvScale x;
+		uvHeight: bounds height asFloat / uvScale y;
+		colorIndices: packedIndices
 ]

--- a/src/SDL3-GPUDemos/SDL3TextScrollDemo.class.st
+++ b/src/SDL3-GPUDemos/SDL3TextScrollDemo.class.st
@@ -39,32 +39,32 @@ SDL3TextScrollDemo >> atlas [
 { #category : 'lifecycle' }
 SDL3TextScrollDemo >> close [
 
-	gpuPipeline ifNotNil: [ 
-		gpuDevice releaseGPUGraphicsPipeline: gpuPipeline.
+	gpuPipeline ifNotNil: [
+		gpuPipeline release.
 		gpuPipeline := nil ].
 
-	baseQuadBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: baseQuadBuffer.
+	baseQuadBuffer ifNotNil: [
+		baseQuadBuffer release.
 		baseQuadBuffer := nil ].
 
-	instanceBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: instanceBuffer.
+	instanceBuffer ifNotNil: [
+		instanceBuffer release.
 		instanceBuffer := nil ].
 
-	instanceTransferBuffer ifNotNil: [ 
-		gpuDevice releaseGPUTransferBuffer: instanceTransferBuffer.
+	instanceTransferBuffer ifNotNil: [
+		instanceTransferBuffer release.
 		instanceTransferBuffer := nil ].
 
-	indexBuffer ifNotNil: [ 
-		gpuDevice releaseGPUBuffer: indexBuffer.
+	indexBuffer ifNotNil: [
+		indexBuffer release.
 		indexBuffer := nil ].
 
-	sampler ifNotNil: [ 
-		gpuDevice releaseGPUSampler: sampler.
+	sampler ifNotNil: [
+		sampler release.
 		sampler := nil ].
 
-	atlasTexture ifNotNil: [ 
-		gpuDevice releaseGPUTexture: atlasTexture.
+	atlasTexture ifNotNil: [
+		atlasTexture release.
 		atlasTexture := nil ].
 
 	super close
@@ -88,46 +88,32 @@ SDL3TextScrollDemo >> doRenderPassesOn: swapchainTexture with: commandBuffer [
 { #category : 'private' }
 SDL3TextScrollDemo >> executeTextRenderPassOn: swapchainTexture with: commandBuffer glyphCount: visibleGlyphCount [
 
-	| renderPass |
 	colorTargetInfos first texture: swapchainTexture.
-	renderPass := commandBuffer
-					 beginGPURenderPassColorTargetInfos: colorTargetInfos
-					 depthStencilTargetInfo: nil.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		vertexBufferBindings first buffer: baseQuadBuffer.
+		vertexBufferBindings second buffer: instanceBuffer.
 
-	renderPass bindGPUGraphicsPipeline: gpuPipeline.
+		renderPass
+			pipeline: gpuPipeline;
+			vertexBuffers: vertexBufferBindings slot: 2;
+			indexBuffer16Bit: indexBinding;
+			fragmentSamplers: textureSamplerBindings slot: 0.
 
-	vertexBufferBindings first buffer: baseQuadBuffer.
-	vertexBufferBindings second buffer: instanceBuffer.
+		uniforms
+			scrollOffsetX: scrollPosition x;
+			scrollOffsetY: scrollPosition y;
+			viewportWidth: window pixelExtent x asFloat;
+			viewportHeight: window pixelExtent y asFloat.
 
-	renderPass bindGPUVertexBuffersFirstSlot: 2 bindings: vertexBufferBindings.
+		commandBuffer
+			pushVertexUniform: uniforms slot: 0.
 
-	renderPass
-		bindGPUIndexBufferBinding: indexBinding
-		indexElementSize: SDL_GPU_INDEXELEMENTSIZE_16BIT.
-
-	renderPass
-		bindGPUFragmentSamplersFirstSlot: 0
-		textureSamplerBindings: textureSamplerBindings.
-
-	uniforms
-		scrollOffsetX: scrollPosition x;
-		scrollOffsetY: scrollPosition y;
-		viewportWidth: window pixelExtent x asFloat;
-		viewportHeight: window pixelExtent y asFloat.
-
-	commandBuffer
-		pushGPUVertexUniformDataSlotIndex: 0
-		data: uniforms
-		length: uniforms class structureSize.
-
-	renderPass
-		drawGPUIndexedPrimitivesNumIndices: 6
-		numInstances: visibleGlyphCount
-		firstIndex: 0
-		vertexOffset: 0
-		firstInstance: 0.
-
-	renderPass end
+		renderPass
+			drawIndexedPrimitives: 6
+			instances: visibleGlyphCount
+			firstIndex: 0
+			vertexOffset: 0
+			firstInstance: 0 ]
 ]
 
 { #category : 'initialization' }
@@ -140,21 +126,15 @@ SDL3TextScrollDemo >> initialize [
 	targetScrollY := 0.0.
 	instanceBufferSize := 0.
 
-	colorTargetInfos := FFIExternalArray
-							externalNewType: SDL_GPUColorTargetInfo
-							size: 1.
-	colorTargetInfos autoRelease.
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR;
-		updateClearColorFrom: Color white.
+		beClear: Color white.
 
 	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 2.
 	textureSamplerBindings := FFIArray
 								  newType: SDL_GPUTextureSamplerBinding
 								  size: 1.
-	indexBinding := SDL_GPUBufferBinding externalNew.
-	indexBinding autoRelease.
+	indexBinding := SDL_GPUBufferBinding offset: 0.
 
 	uniforms := SDL3TextScrollUniforms new.
 
@@ -170,7 +150,7 @@ SDL3TextScrollDemo >> initialize [
 	"4: Transparent (Standard BG)"
 	uniforms setColorAt: 5 r: 0.0 g: 0.0 b: 0.0 a: 0.0.
 	"5: Light Gray (Header BG)"
-	uniforms setColorAt: 6 r: 0.9 g: 0.9 b: 0.9 a: 1.0.
+	uniforms setColorAt: 6 r: 0.9 g: 0.9 b: 0.9 a: 1.0
 ]
 
 { #category : 'initialization' }
@@ -179,12 +159,12 @@ SDL3TextScrollDemo >> initializeAtlas [
 	| generator scale chars |
 	generator := SDL3TextAtlasGenerator new.
 	scale := window pixelDensity @ window pixelDensity.
-	
+
 	"Efficient character set: Standard ASCII 32-126 + any other char found in the first 1MB of text"
 	chars := ((32 to: 126) collect: [ :i | i asCharacter ]) asSet.
 	1 to: (text size min: 1e6) do: [ :i | chars add: (text at: i) ].
 	chars := (chars reject: [ :c | c isSeparator or: [ c asciiValue < 32 ] ]) asSortedCollection.
-	
+
 	atlas := generator generateAtlasFor: chars deviceScale: scale.
 	layoutEngine := SDL3TextLayoutEngine new atlas: atlas.
 	layoutEngine layoutString: text
@@ -193,33 +173,22 @@ SDL3TextScrollDemo >> initializeAtlas [
 { #category : 'initialization' }
 SDL3TextScrollDemo >> initializeBaseQuadBuffer [
 
-	| byteSize transferBuffer mappedAddress vertices commandBuffer |
-	byteSize := SDL3GPUQuadVertex structureSize * 4.
-	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
-	baseQuadBuffer := gpuDevice 
-		newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
-		size: byteSize.
+	baseQuadBuffer := gpuDevice
+		                  newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
+		                  size: SDL3GPUQuadVertex structureSize * 4.
 
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: true.
-	vertices := FFIArray fromHandle: mappedAddress type: SDL3GPUQuadVertex size: 4.
-	
-	"Base quad: 0..1 in x, 0..-1 in y"
-	(vertices at: 1) x: 0; y: 0; z: 0; u: 0; v: 0.
-	(vertices at: 2) x: 1; y: 0; z: 0; u: 1; v: 0.
-	(vertices at: 3) x: 1; y: -1; z: 0; u: 1; v: 1.
-	(vertices at: 4) x: 0; y: -1; z: 0; u: 0; v: 1.
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
-
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0)
-		destination: (SDL_GPUBufferRegion new buffer: baseQuadBuffer; offset: 0; size: byteSize)
-		cycle: true;
-		end.
-	commandBuffer submit.
-
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: baseQuadBuffer
+			type: SDL3GPUQuadVertex
+			count: 4
+			cycle: true
+			fillWith: [ :vertices |
+				"Base quad: 0..1 in x, 0..-1 in y"
+				vertices first  x: 0; y:  0; z: 0; u: 0; v: 0.
+				vertices second x: 1; y:  0; z: 0; u: 1; v: 0.
+				vertices third  x: 1; y: -1; z: 0; u: 1; v: 1.
+				vertices fourth x: 0; y: -1; z: 0; u: 0; v: 1 ] ]
 ]
 
 { #category : 'initialization' }
@@ -235,107 +204,108 @@ SDL3TextScrollDemo >> initializeGPUResources [
 { #category : 'initialization' }
 SDL3TextScrollDemo >> initializeIndexBuffer [
 
-	| byteSize transferBuffer mappedAddress indices commandBuffer |
-	byteSize := 6 * 2.
-	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
-	indexBuffer := gpuDevice 
-		newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
-		size: byteSize.
+	indexBuffer := gpuDevice
+		               newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_INDEX
+		               size: 6 * 2.
 	indexBinding buffer: indexBuffer.
 
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: true.
-	indices := FFIArray fromHandle: mappedAddress type: FFIUInt16 size: 6.
-	indices at: 1 put: 0; at: 2 put: 1; at: 3 put: 2; at: 4 put: 0; at: 5 put: 2; at: 6 put: 3.
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
-
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0)
-		destination: (SDL_GPUBufferRegion new buffer: indexBuffer; offset: 0; size: byteSize)
-		cycle: true;
-		end.
-	commandBuffer submit.
-
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTo: indexBuffer
+			type: FFIUInt16
+			count: 6
+			cycle: true
+			fillWith: [ :indices |
+				indices
+					at: 1 put: 0;
+					at: 2 put: 1;
+					at: 3 put: 2;
+					at: 4 put: 0;
+					at: 5 put: 2;
+					at: 6 put: 3 ] ]
 ]
 
 { #category : 'initialization' }
 SDL3TextScrollDemo >> initializePipeline [
 
-	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets pipelineCreateInfo |
+	| vertexShader fragmentShader vertexBindings vertexAttributes colorTargets |
+
 	vertexShader := SDL3TextScrollVertexShaderSource newShaderAmong: shaderFormats device: gpuDevice.
 	fragmentShader := SDL3TextScrollFragmentShaderSource newShaderAmong: shaderFormats device: gpuDevice.
 
-	vertexBindings := FFIExternalArray externalNewType: SDL_GPUVertexBufferDescription size: 2.
-	vertexBindings autoRelease.
+	vertexBindings := SDL_GPUVertexBufferDescription safeNewArray: 2.
 	vertexBindings first
 		slot: 2;
 		inputRate: SDL_GPU_VERTEXINPUTRATE_VERTEX;
 		instanceStepRate: 0;
 		pitch: SDL3GPUQuadVertex structureSize.
-	(vertexBindings at: 2)
+	vertexBindings second
 		slot: 3;
 		inputRate: SDL_GPU_VERTEXINPUTRATE_INSTANCE;
 		instanceStepRate: 0;
 		pitch: SDL3TextScrollInstance structureSize.
 
-	vertexAttributes := FFIExternalArray externalNewType: SDL_GPUVertexAttribute size: 6.
-	vertexAttributes autoRelease.
-	(vertexAttributes at: 1) bufferSlot: 2; format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3; location: 0; offset: 0.
-	(vertexAttributes at: 2) bufferSlot: 2; format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2; location: 1; offset: 12.
-	(vertexAttributes at: 3) bufferSlot: 3; format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2; location: 2; offset: 0.
-	(vertexAttributes at: 4) bufferSlot: 3; format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2; location: 3; offset: 8.
-	(vertexAttributes at: 5) bufferSlot: 3; format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4; location: 4; offset: 16.
-	(vertexAttributes at: 6) bufferSlot: 3; format: SDL_GPU_VERTEXELEMENTFORMAT_UINT; location: 5; offset: 32.
+	vertexAttributes := SDL_GPUVertexAttribute safeNewArray: 6.
+	vertexAttributes first
+		bufferSlot: 2;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
+		location: 0;
+		offset: 0.
+	vertexAttributes second
+		bufferSlot: 2;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
+		location: 1;
+		offset: 12.
+	vertexAttributes third
+		bufferSlot: 3;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
+		location: 2;
+		offset: 0.
+	vertexAttributes fourth
+		bufferSlot: 3;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
+		location: 3;
+		offset: 8.
+	vertexAttributes fifth
+		bufferSlot: 3;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4;
+		location: 4;
+		offset: 16.
+	vertexAttributes sixth
+		bufferSlot: 3;
+		format: SDL_GPU_VERTEXELEMENTFORMAT_UINT;
+		location: 5;
+		offset: 32.
 
-	colorTargets := FFIExternalArray externalNewType: SDL_GPUColorTargetDescription size: 1.
-	colorTargets autoRelease.
-	colorTargets first 
+	colorTargets := SDL_GPUColorTargetDescription safeNewArray: 1.
+	colorTargets first
 		format: (gpuDevice getGPUSwapchainTextureFormatIntoWindow: window);
-		blendState: (SDL_GPUColorTargetBlendState new
-				enableBlend: true;
-				srcColorBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-				dstColorBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-				colorBlendOp: SDL_GPU_BLENDOP_ADD;
-				srcAlphaBlendfactor: SDL_GPU_BLENDFACTOR_SRC_ALPHA;
-				dstAlphaBlendfactor: SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA;
-				alphaBlendOp: SDL_GPU_BLENDOP_ADD;
-				yourself).
+		blendState: SDL_GPUColorTargetBlendState newAlphaBlend.
 
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
-		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
-		vertexShader: vertexShader;
-		fragmentShader: fragmentShader.
-	pipelineCreateInfo targetInfo
-		colorTargetDescriptions: colorTargets;
-		numColorTargets: 1;
-		hasDepthStencilTarget: false.
-	pipelineCreateInfo vertexInputState
-		vertexBufferDescriptions: vertexBindings;
-		numVertexBuffers: 2;
-		vertexAttributes: vertexAttributes;
-		numVertexAttributes: 6.
+	gpuPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
+			vertex: vertexShader
+			fragment: fragmentShader
+			targets: colorTargets.
+		info vertexInputState
+			attributes: vertexAttributes
+			bindings: vertexBindings ].
 
-	gpuPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
-
-	gpuDevice releaseGPUShader: vertexShader.
-	gpuDevice releaseGPUShader: fragmentShader
+	vertexShader release.
+	fragmentShader release
 ]
 
 { #category : 'initialization' }
 SDL3TextScrollDemo >> initializeSampler [
 
-	sampler := gpuDevice newGPUSamplerCreateinfo:
-		(SDL_GPUSamplerCreateInfo new
+	sampler := gpuDevice newSampler: [ :info |
+		info
 			minFilter: SDL_GPU_FILTER_NEAREST;
 			magFilter: SDL_GPU_FILTER_NEAREST;
-			mipmapMode: SDL_GPU_FILTER_NEAREST;
+			mipmapMode: SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
 			addressModeU: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
 			addressModeV: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-			addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-			yourself).
+			addressModeW: SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE ].
 
 	textureSamplerBindings first sampler: sampler
 ]
@@ -343,30 +313,22 @@ SDL3TextScrollDemo >> initializeSampler [
 { #category : 'initialization' }
 SDL3TextScrollDemo >> initializeTexture [
 
-	| transferBuffer mappedAddress commandBuffer byteSize |
 	atlasTexture := gpuDevice
-		new2DGPUTextureFormat: SDL_GPU_TEXTUREFORMAT_R8_UNORM
-		usage: SDL_GPU_TEXTUREUSAGE_SAMPLER
-		width: atlas width
-		height: atlas height.
-	
+		                new2DGPUTextureFormat: SDL_GPU_TEXTUREFORMAT_R8_UNORM
+		                usage: SDL_GPU_TEXTUREUSAGE_SAMPLER
+		                width: atlas width
+		                height: atlas height.
+
 	"Cairo A8 surfaces may have padding (stride). We forced width to be a multiple of 4, so stride == width."
-	byteSize := atlas width * atlas height.
-	
-	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: true.
-	LibC memCopy: atlas dataPtr to: mappedAddress size: byteSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
-	
-	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUTextureSource: (SDL_GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0)
-		destination: (SDL_GPUTextureRegion new texture: atlasTexture; w: atlas width; h: atlas height; d: 1)
-		cycle: true;
-		end.
-	commandBuffer submit.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
-	
+	gpuDevice uploadToGPUDo: [ :uploader |
+		uploader
+			uploadTexture: atlasTexture
+			fromPointer: atlas dataPtr
+			byteSize: atlas width * atlas height
+			w: atlas width
+			h: atlas height
+			cycle: true ].
+
 	textureSamplerBindings first texture: atlasTexture
 ]
 
@@ -381,7 +343,7 @@ SDL3TextScrollDemo >> instanceStride [
 SDL3TextScrollDemo >> open [
 
 	"Load the large text file"
-	[ text := FileLocator changes readStream next: 10e6 ] on: Error do: [ :ex | 
+	[ text := FileLocator changes readStream next: 10e6 ] on: Error do: [ :ex |
 		text := 'Error loading changes file: ', ex messageText ].
 
 	super open.
@@ -392,12 +354,13 @@ SDL3TextScrollDemo >> open [
 { #category : 'private' }
 SDL3TextScrollDemo >> prepareInstanceBufferWith: commandBuffer [
 
-	| visibleLineRange firstLine lastLine visibleGlyphCount instanceDataSize mappedAddress instances |
+	| visibleLineRange firstLine lastLine visibleGlyphCount |
+
 	visibleLineRange := layoutEngine visibleLineRangeIn:
 							(scrollPosition extent: window pixelExtent).
 
 	"Optimization: Skip layout and upload if the visible range is the same"
-	visibleLineRange = lastVisibleLineRange ifTrue: [ 
+	visibleLineRange = lastVisibleLineRange ifTrue: [
 		^ lastVisibleGlyphCount ].
 
 	firstLine := visibleLineRange x.
@@ -408,54 +371,38 @@ SDL3TextScrollDemo >> prepareInstanceBufferWith: commandBuffer [
 							 characterCountFromLine: firstLine
 							 to: lastLine) + 100.
 
-	instanceDataSize := visibleGlyphCount
-						* SDL3TextScrollInstance structureSize.
-
 	"Recycle or resize GPU buffers"
-	(instanceBuffer isNil or: [ instanceBufferSize < instanceDataSize ]) 
-		ifTrue: [ 
-			instanceBuffer ifNotNil: [ 
-				gpuDevice releaseGPUBuffer: instanceBuffer ].
-			instanceTransferBuffer ifNotNil: [ 
-				gpuDevice releaseGPUTransferBuffer: instanceTransferBuffer ].
-			instanceBufferSize := (instanceDataSize * 1.5) ceiling.
+	(instanceBuffer isNil or: [ instanceBufferSize < (visibleGlyphCount * SDL3TextScrollInstance structureSize) ])
+		ifTrue: [
+			instanceBuffer ifNotNil: [
+				instanceBuffer release ].
+			instanceTransferBuffer ifNotNil: [
+				instanceTransferBuffer release ].
+			instanceBufferSize := (visibleGlyphCount * SDL3TextScrollInstance structureSize * 1.5) ceiling.
 			instanceBuffer := gpuDevice
 								 newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX
 								 size: instanceBufferSize.
 			instanceTransferBuffer := gpuDevice newUploadTransferBuffer:
 										 instanceBufferSize ].
 
-	mappedAddress := gpuDevice
-						mapGPUTransferBuffer: instanceTransferBuffer
-						cycle: true.
-	instances := FFIArray
-					fromHandle: mappedAddress
-					type: SDL3TextScrollInstance
-					size: visibleGlyphCount.
+	commandBuffer uploadToGPUDo: [ :uploader |
+		uploader
+			transferBuffer: instanceTransferBuffer
+			uploadTo: instanceBuffer
+			type: SDL3TextScrollInstance
+			count: visibleGlyphCount
+			cycle: true
+			fillWith: [ :mappedInstances |
+				"Lazy Layout into the buffer"
+				visibleGlyphCount := layoutEngine
+										layoutVisibleLinesOf: text
+										in: (scrollPosition extent: window pixelExtent)
+										into: mappedInstances ] ].
 
-	"Lazy Layout into the buffer"
-	visibleGlyphCount := layoutEngine
-							layoutVisibleLinesOf: text
-							in: (scrollPosition extent: window pixelExtent)
-							into: instances.
-
-	gpuDevice unmapGPUTransferBuffer: instanceTransferBuffer.
-
-	visibleGlyphCount = 0 ifTrue: [ 
+	visibleGlyphCount = 0 ifTrue: [
 		lastVisibleLineRange := visibleLineRange.
 		lastVisibleGlyphCount := 0.
 		^ 0 ].
-
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new
-				transferBuffer: instanceTransferBuffer;
-				offset: 0)
-		destination: (SDL_GPUBufferRegion new
-				buffer: instanceBuffer;
-				offset: 0;
-				size: instanceBufferSize)
-		cycle: true;
-		end.
 
 	lastVisibleLineRange := visibleLineRange.
 	lastVisibleGlyphCount := visibleGlyphCount.
@@ -470,17 +417,12 @@ SDL3TextScrollDemo >> step [
 	"Smoothly interpolate current scroll position towards target"
 	lerpFactor := 0.3.
 	scrollPosition := scrollPosition x @ (scrollPosition y + ((targetScrollY - scrollPosition y) * lerpFactor)).
-	
+
 	"Avoid endless micro-steps"
-	(targetScrollY - scrollPosition y) abs < 0.1 ifTrue: [ 
+	(targetScrollY - scrollPosition y) abs < 0.1 ifTrue: [
 		scrollPosition := scrollPosition x @ targetScrollY ].
 
 	self render
-]
-
-{ #category : 'accessing' }
-SDL3TextScrollDemo >> targetScrollY [
-	^ targetScrollY
 ]
 
 { #category : 'accessing' }
@@ -503,5 +445,5 @@ SDL3TextScrollDemo >> visitMouseWheelEvent: aMouseWheelEvent [
 	"Clamp to boundaries"
 	targetScrollY := targetScrollY max: 0.0.
 	maxScrollY := (layoutEngine totalHeight - window pixelExtent y max: 0) asFloat.
-	targetScrollY := targetScrollY min: maxScrollY.
+	targetScrollY := targetScrollY min: maxScrollY
 ]

--- a/src/SDL3-GPUDemos/SDL3TextScrollFragmentShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3TextScrollFragmentShaderSource.class.st
@@ -45,7 +45,7 @@ SamplerState atlasSampler : register(s0, space2);
 float4 main(VertexOutput input) : SV_Target0 {
  // R8 texture stores data in the red channel
  float mask = atlasTexture.Sample(atlasSampler, input.uv);
- 
+
  return lerp(input.bgColor, input.fgColor, mask);
 }'
 ]

--- a/src/SDL3-GPUDemos/SDL3TextScrollInstance.class.st
+++ b/src/SDL3-GPUDemos/SDL3TextScrollInstance.class.st
@@ -19,6 +19,8 @@ Class {
 
 { #category : 'field definition' }
 SDL3TextScrollInstance class >> fieldsDesc [
+	<script: 'self rebuildFieldAccessors'>
+
 	^ #(
 	float posX;
 	float posY;

--- a/src/SDL3-GPUDemos/SDL3TextScrollUniforms.class.st
+++ b/src/SDL3-GPUDemos/SDL3TextScrollUniforms.class.st
@@ -78,6 +78,8 @@ Class {
 
 { #category : 'field definition' }
 SDL3TextScrollUniforms class >> fieldsDesc [
+	<script: 'self rebuildFieldAccessors'>
+
 	^ #(
 	float scrollOffsetX;
 	float scrollOffsetY;

--- a/src/SDL3-GPUDemos/SDL3TextScrollVertexShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3TextScrollVertexShaderSource.class.st
@@ -32,7 +32,10 @@ SDL3TextScrollVertexShaderSource class >> base64SPVCode [
 
 { #category : 'accessing' }
 SDL3TextScrollVertexShaderSource class >> hlslSource [
-	^ 'cbuffer Params : register(b0, space1) {
+	<script: 'self compileBase64CodeFromHLSLSource'>
+
+	^ '
+cbuffer Params : register(b0, space1) {
    float scrollOffsetX;
    float scrollOffsetY;
    float viewportWidth;
@@ -58,22 +61,22 @@ struct VertexOutput {
 
 VertexOutput main(VertexInput input) {
  VertexOutput output;
- 
+
  float2 screenPos = input.instPosition + (float2(input.basePosition.x, -input.basePosition.y) * input.instExtent);
- 
+
  // Apply scroll
  screenPos.x -= scrollOffsetX;
  screenPos.y -= scrollOffsetY;
- 
+
  // Convert to NDC (-1 to 1)
  float ndcX = (screenPos.x / viewportWidth) * 2.0 - 1.0;
  float ndcY = 1.0 - (screenPos.y / viewportHeight) * 2.0;
 
  output.position = float4(ndcX, ndcY, 0.0, 1.0);
- 
+
  // Calculate UV within the atlas
  output.uv = input.instUVBounds.xy + (input.baseUV * input.instUVBounds.zw);
- 
+
  uint fgIdx = input.colorIndices & 0xFFFF;
  uint bgIdx = (input.colorIndices >> 16) & 0xFFFF;
  output.fgColor = colors[fgIdx];

--- a/src/SDL3-GPUDemos/SDL3TileManager.class.st
+++ b/src/SDL3-GPUDemos/SDL3TileManager.class.st
@@ -41,16 +41,16 @@ SDL3TileManager >> visibleTileKeys [
 	| lod fractalTileSize minFractal maxFractal startX startY endX endY keys |
 	lod := self lod.
 	fractalTileSize := 4.0 / (2 ** lod). "Width 4.0 is base scale"
-	
+
 	"Viewport bounds in fractal space"
 	minFractal := camera logicalToFractal: 0 @ 0.
 	maxFractal := camera logicalToFractal: camera viewportExtent.
-	
+
 	startX := ((minFractal x min: maxFractal x) / fractalTileSize) floor.
 	endX := ((minFractal x max: maxFractal x) / fractalTileSize) floor.
 	startY := ((minFractal y min: maxFractal y) / fractalTileSize) floor.
 	endY := ((minFractal y max: maxFractal y) / fractalTileSize) floor.
-	
+
 	keys := OrderedCollection new.
 	startX to: endX do: [ :x |
 		startY to: endY do: [ :y |

--- a/src/SDL3-GPUDemos/SDL3TiledMapCamera.class.st
+++ b/src/SDL3-GPUDemos/SDL3TiledMapCamera.class.st
@@ -34,7 +34,7 @@ SDL3TiledMapCamera >> fractalToLogical: aPoint [
 	| fractalWidth fractalHeight relativePos |
 	fractalWidth := 4.0 / zoomLevel.
 	fractalHeight := fractalWidth * (viewportExtent y / viewportExtent x).
-	
+
 	relativePos := (aPoint - center) / (fractalWidth @ fractalHeight).
 	^ relativePos + (0.5 @ 0.5)
 ]
@@ -46,7 +46,7 @@ SDL3TiledMapCamera >> fractalToLogicalRect: aRect [
 	| p1 p2 |
 	p1 := self fractalToLogical: aRect origin.
 	p2 := self fractalToLogical: aRect corner.
-	
+
 	^ Rectangle origin: (p1 min: p2) corner: (p1 max: p2)
 ]
 
@@ -67,7 +67,7 @@ SDL3TiledMapCamera >> logicalToFractal: aPoint [
 	| relativePos fractalWidth fractalHeight |
 	fractalWidth := 4.0 / zoomLevel.
 	fractalHeight := fractalWidth * (viewportExtent y / viewportExtent x).
-	
+
 	"x: 0 (left) -> -0.5, 1 (right) -> 0.5
 	y: 0 (top)  -> 0.5, 1 (bottom) -> -0.5"
 	relativePos := (aPoint x / viewportExtent x - 0.5) @ (0.5 - (aPoint y / viewportExtent y)).
@@ -84,7 +84,7 @@ SDL3TiledMapCamera >> normalizedToFractal: aNormalizedPoint [
 	| relativePos fractalWidth fractalHeight |
 	fractalWidth := 4.0 / zoomLevel.
 	fractalHeight := fractalWidth * (viewportExtent y / viewportExtent x).
-	
+
 	"x: 0 (left) -> -0.5, 1 (right) -> 0.5
 	y: 0 (top)  -> 0.5, 1 (bottom) -> -0.5"
 	relativePos := (aNormalizedPoint x - 0.5) @ (0.5 - aNormalizedPoint y).
@@ -98,11 +98,11 @@ SDL3TiledMapCamera >> panByNormalized: aDeltaNormalized [
 	| fractalWidth fractalHeight dxFractal dyFractal |
 	fractalWidth := 4.0 / zoomLevel.
 	fractalHeight := fractalWidth * (viewportExtent y / viewportExtent x).
-	
+
 	dxFractal := aDeltaNormalized x * fractalWidth.
 	dyFractal := aDeltaNormalized y * fractalHeight.
-	
-	"Standard drag-to-pan: 
+
+	"Standard drag-to-pan:
 	Mouse moves right (+dx) -> Camera moves left (-dx)
 	Mouse moves down (+dy) -> Camera moves up (+dy) since fractal math Y is up"
 	center := center + (dxFractal negated @ dyFractal).

--- a/src/SDL3-GPUDemos/SDL3TiledMapCameraTest.class.st
+++ b/src/SDL3-GPUDemos/SDL3TiledMapCameraTest.class.st
@@ -1,0 +1,93 @@
+"
+Tests for the Tiled Map Camera.
+"
+Class {
+	#name : 'SDL3TiledMapCameraTest',
+	#superclass : 'TestCase',
+	#category : 'SDL3-GPUDemos-TiledMap',
+	#package : 'SDL3-GPUDemos',
+	#tag : 'TiledMap'
+}
+
+{ #category : 'tests' }
+SDL3TiledMapCameraTest >> testInitialization [
+
+	| camera |
+	camera := SDL3TiledMapCamera new.
+	self assert: camera zoomLevel equals: 1.0.
+	self assert: camera center equals: 0 @ 0
+]
+
+{ #category : 'tests' }
+SDL3TiledMapCameraTest >> testLogicalToFractal [
+
+	| camera fractalPos |
+	camera := SDL3TiledMapCamera new.
+	camera viewportExtent: 1280 @ 720.
+	camera center: 0 @ 0.
+	camera zoomLevel: 1.0. "Assume width of 4.0 in fractal space"
+
+	"Center of screen should be center of fractal"
+	fractalPos := camera logicalToFractal: 640 @ 360.
+	self assert: fractalPos x equals: 0.
+	self assert: fractalPos y equals: 0.
+
+	"Top left of screen (Y is positive in fractal math)"
+	fractalPos := camera logicalToFractal: 0 @ 0.
+	self assert: (fractalPos closeTo: -2 @ 1.125)
+]
+
+{ #category : 'tests' }
+SDL3TiledMapCameraTest >> testPanByNormalized [
+
+	| camera |
+	camera := SDL3TiledMapCamera new.
+	camera viewportExtent: 1000 @ 1000.
+	camera center: 0 @ 0.
+	camera zoomLevel: 1.0. "fractal size 4x4"
+
+	"Pan right by 10% (0.1 normalized)"
+	camera panByNormalized: 0.1 @ 0.0.
+	"Mouse moves +X -> Camera moves -X -> Center should be -0.4"
+	self assert: (camera center x closeTo: -0.4).
+
+	"Pan down by 10%"
+	camera panByNormalized: 0.0 @ 0.1.
+	"Mouse moves +Y (down) -> Camera moves +Y (math up) -> Center Y should be 0.4"
+	self assert: (camera center y closeTo: 0.4)
+]
+
+{ #category : 'tests' }
+SDL3TiledMapCameraTest >> testZoomByAroundNormalizedPoint [
+
+	| camera fractalAtMouse |
+	camera := SDL3TiledMapCamera new.
+	camera viewportExtent: 1000 @ 1000.
+	camera center: 0 @ 0.
+	camera zoomLevel: 1.0.
+
+	"Normalized point (0.75, 0.25) is top-right quadrant"
+	fractalAtMouse := camera normalizedToFractal: 0.75 @ 0.25.
+	self assert: fractalAtMouse equals: 1.0 @ 1.0.
+
+	"Zoom in by 2.0 around that point"
+	camera zoomBy: 2.0 aroundNormalizedPoint: 0.75 @ 0.25.
+
+	"The fractal point under the mouse should still be (1.0, 1.0)"
+	self assert: (camera zoomLevel closeTo: 2.0).
+	self assert: ((camera normalizedToFractal: 0.75 @ 0.25) closeTo: 1.0 @ 1.0)
+]
+
+{ #category : 'tests' }
+SDL3TiledMapCameraTest >> testZoomLimits [
+
+	| camera |
+	camera := SDL3TiledMapCamera new.
+	camera zoomLevel: 1.0.
+
+	camera zoomBy: 0.1. "Would be 0.1"
+	self assert: camera zoomLevel equals: 0.5. "Min limit"
+
+	camera zoomBy: 1000000.0.
+	self assert: camera zoomLevel equals: 131072.0. "Max limit"
+]

--- a/src/SDL3-GPUDemos/SDL3VortexShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3VortexShaderSource.class.st
@@ -58,30 +58,30 @@ float4 main(PSInput input) : SV_Target
 {
    // Center the coordinates (-0.5 to 0.5)
    float2 centeredUV = input.uv - 0.5;
-   
+
    // Calculate distance from center
    float dist = length(centeredUV);
-   
+
    // Calculate rotation angle based on distance and time
    // The distortion decreases at the center (dist) to preserve the focal point
    float angle = (TwistAmount * dist) + time;
-   
+
    // precise sine/cosine for rotation
    float s, c;
    sincos(angle, s, c);
-   
+
    // Rotate the UV coordinates
    float2 rotatedUV = float2(
        centeredUV.x * c - centeredUV.y * s,
        centeredUV.x * s + centeredUV.y * c
    );
-   
+
    // Un-center the coordinates back to 0.0 to 1.0 range
    rotatedUV += 0.5;
-   
+
    // Sample texture
    float4 color = InputTexture.Sample(InputSampler, rotatedUV) * input.color;
-   
+
    return float4(color.rgb, 1.0);
 }
 '

--- a/src/SDL3-GPUDemos/SDL3WaterShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3WaterShaderSource.class.st
@@ -43,7 +43,7 @@ SamplerState InputSampler : register(s0, space2);
 cbuffer Params : register(b0, space3)
 {
    float time;
-   float2 resolution; 
+   float2 resolution;
 }
 
 static const float Strength = 0.01; // 0.01 for subtle, 0.5 for crazy
@@ -57,14 +57,14 @@ struct PSInput
 float4 main(PSInput input) : SV_Target
 {
    float2 p = input.uv;
-   
+
    // Create two sine waves moving in different directions
    float x = sin(p.y * 4.0 + time) * cos(p.x * 10.0 + time * 0.5);
    float y = sin(p.x * 4.0 + time) * cos(p.y * 10.0 + time * 0.3);
-   
+
    // Apply the wave as an offset to the UVs
    float2 offset = float2(x, y) * Strength;
-   
+
    // Sample the texture with the distorted coordinates
    float4 color = InputTexture.Sample(InputSampler, p + offset);
 

--- a/src/SDL3-GPUDemos/SDL3WigglesShaderSource.class.st
+++ b/src/SDL3-GPUDemos/SDL3WigglesShaderSource.class.st
@@ -61,7 +61,7 @@ float4 main(PSInput input) : SV_Target
 {
    // 1. Base UV from input (Equivalent to fragCoord/resolution.xy)
    float2 uv = input.uv;
-   
+
    // 2. Reconstruct "p" (the centered coordinate space)
    // Corresponds to: (2. * fragCoord - resolution.xy)
    // Derived as: resolution * (2.0 * uv - 1.0)
@@ -70,14 +70,14 @@ float4 main(PSInput input) : SV_Target
    // 3. Calculate leg factors (Vignette/Masking based on aspect ratio)
    float legsx = 1.0 - length(p / resolution.x);
    float legsy = 1.0 - length(p / resolution.y);
-   
+
    // 4. Calculate offsets
    float xOffset = sin((time * speed) + uv.y * strength) * (distortion * legsx);
    float yOffset = sin((time * speed) + uv.x * strength) * (distortion * legsy);
-   
+
    // 5. Sample texture
    float4 tex = InputTexture.Sample(InputSampler, uv + float2(xOffset, yOffset));
-   
+
    // 6. Return result
    return tex * input.color;
 }

--- a/src/SDL3-Graphics-Tests/SDL3GraphicsPipelineTest.class.st
+++ b/src/SDL3-Graphics-Tests/SDL3GraphicsPipelineTest.class.st
@@ -49,7 +49,9 @@ SDL3GraphicsPipelineTest >> test01ClearTarget [
 	Begin a render pass on an off-screen texture with SDL_GPU_LOADOP_CLEAR and a specific clear color.
 	Assert that the texture is correctly cleared."
 
-	| colorTarget commandBuffer renderPass transferBuffer mappedAddress resultData texWidth texHeight byteSize colorTargetInfos |
+	| colorTarget commandBuffer transferBuffer resultData texWidth texHeight byteSize colorTargetInfos |
+
+
 	
 	texWidth := 64.
 	texHeight := 64.
@@ -72,41 +74,35 @@ SDL3GraphicsPipelineTest >> test01ClearTarget [
 		loadOp: SDL_GPU_LOADOP_CLEAR.
 	colorTargetInfos first clearColor r: 1.0; g: 0.0; b: 0.0; a: 1.0. "Red"
 
-	renderPass := commandBuffer
-		 beginGPURenderPassColorTargetInfos: colorTargetInfos
-		 numColorTargets: 1
-		 depthStencilTargetInfo: nil.
-	renderPass end.
-	
+	commandBuffer renderPassTargets: colorTargetInfos depthStencil: nil do: [ :renderPass | ].
+		
 	commandBuffer submit.
 	
 	"3. Download results"
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUTextureSource: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
-		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadTexture: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
+			destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"4. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
-	
-	"Check a few pixels (first, middle, last) - Should be solid Red (255, 0, 0, 255)"
-	{ 1 . (byteSize // 2) + 1 . (byteSize - 3) } do: [ :baseIdx |
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
+		
+		"Check a few pixels (first, middle, last) - Should be solid Red (255, 0, 0, 255)"
+		{ 1 . (byteSize // 2) + 1 . (byteSize - 3) } do: [ :baseIdx |
 		self assert: (resultData at: baseIdx) equals: 255. "R"
 		self assert: (resultData at: baseIdx + 1) equals: 0. "G"
 		self assert: (resultData at: baseIdx + 2) equals: 0. "B"
-		self assert: (resultData at: baseIdx + 3) equals: 255. "A" ].
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+		self assert: (resultData at: baseIdx + 3) equals: 255. "A" ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUTexture: colorTarget.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	colorTarget release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -114,7 +110,9 @@ SDL3GraphicsPipelineTest >> test02FullscreenQuad [
 	"Case 2: Fullscreen Quad
 	Draws a solid green quad covering the whole screen using explicit vertices."
 
-	| colorTarget vertexBuffer graphicsPipeline commandBuffer renderPass transferBuffer mappedAddress resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions pipelineCreateInfo vertexBufferBindings |
+	| colorTarget vertexBuffer graphicsPipeline commandBuffer transferBuffer resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions vertexBufferBindings |
+
+
 	
 	texWidth := 64.
 	texHeight := 64.
@@ -144,16 +142,15 @@ SDL3GraphicsPipelineTest >> test02FullscreenQuad [
 	
 	"Upload vertex data"
 	transferBuffer := gpuDevice newUploadTransferBuffer: 6 * SDL3GPUQuadVertex structureSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: vertexData to: mappedAddress size: 6 * SDL3GPUQuadVertex structureSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: vertexData to: mappedAddress size: 6 * SDL3GPUQuadVertex structureSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: 6 * SDL3GPUQuadVertex structureSize; yourself)
-		cycle: false;
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: 6 * SDL3GPUQuadVertex structureSize; yourself)
+			cycle: false ].
 
 	"2. Create Pipeline"
 	vertexBindings := FFIExternalArray externalNewType: SDL_GPUVertexBufferDescription size: 1.
@@ -175,23 +172,23 @@ SDL3GraphicsPipelineTest >> test02FullscreenQuad [
 		format: SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
 		blendState: SDL_GPUColorTargetBlendState new.
 
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
+	graphicsPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
 		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 		vertexShader: (SDL3TestGraphicsQuadVertexShaderSource newShaderAmong: shaderFormats device: gpuDevice);
 		fragmentShader: (SDL3TestGraphicsQuadFragmentShaderSource newShaderAmong: shaderFormats device: gpuDevice).
-	
-	pipelineCreateInfo vertexInputState
+		
+		info vertexInputState
 		vertexBufferDescriptions: vertexBindings;
 		numVertexBuffers: 1;
 		vertexAttributes: vertexAttributes;
 		numVertexAttributes: 1.
-	
-	pipelineCreateInfo targetInfo
+		
+		info targetInfo
 		colorTargetDescriptions: colorTargetDescriptions;
 		numColorTargets: 1.
-
-	graphicsPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
+		
+	].
 
 	"3. Render"
 	colorTargetInfos := FFIArray newType: SDL_GPUColorTargetInfo size: 1.
@@ -201,51 +198,44 @@ SDL3GraphicsPipelineTest >> test02FullscreenQuad [
 		loadOp: SDL_GPU_LOADOP_CLEAR.
 	colorTargetInfos first clearColor r: 0.0; g: 0.0; b: 0.0; a: 1.0. "Initial black"
 
-	renderPass := commandBuffer
-		 beginGPURenderPassColorTargetInfos: colorTargetInfos
-		 numColorTargets: 1
-		 depthStencilTargetInfo: nil.
-	
 	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
 	vertexBufferBindings first buffer: vertexBuffer; offset: 0.
 	
-	renderPass
-		bindGPUGraphicsPipeline: graphicsPipeline;
-		bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings numBindings: 1;
-		drawGPUPrimitivesNumVertices: 6 numInstances: 1 firstVertex: 0 firstInstance: 0;
-		end.
+	commandBuffer renderPassTargets: colorTargetInfos depthStencil: nil do: [ :renderPass |
+		renderPass
+			pipeline: graphicsPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			drawPrimitives: 6 instances: 1 firstVertex: 0 firstInstance: 0 ].
 	
 	commandBuffer submit.
 	
 	"4. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUTextureSource: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
-		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadTexture: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
+			destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"5. Assert - Should be solid Green (0, 255, 0, 255)"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
-	
-	{ 1 . (byteSize // 2) + 1 . (byteSize - 3) } do: [ :baseIdx |
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
+		
+		{ 1 . (byteSize // 2) + 1 . (byteSize - 3) } do: [ :baseIdx |
 		self assert: (resultData at: baseIdx) equals: 0. "R"
 		self assert: (resultData at: baseIdx + 1) equals: 255. "G"
 		self assert: (resultData at: baseIdx + 2) equals: 0. "B"
-		self assert: (resultData at: baseIdx + 3) equals: 255. "A" ].
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+		self assert: (resultData at: baseIdx + 3) equals: 255. "A" ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUGraphicsPipeline: graphicsPipeline.
-	gpuDevice releaseGPUBuffer: vertexBuffer.
-	gpuDevice releaseGPUTexture: colorTarget.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	graphicsPipeline release.
+	vertexBuffer release.
+	colorTarget release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -253,7 +243,9 @@ SDL3GraphicsPipelineTest >> test03VertexColors [
 	"Case 3: Vertex Attributes & Interpolation
 	Draws a triangle with Red, Green, Blue vertices and verifies interpolated colors."
 
-	| colorTarget vertexBuffer graphicsPipeline commandBuffer renderPass transferBuffer mappedAddress resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions pipelineCreateInfo vertexBufferBindings topIdx centerIdx |
+	| colorTarget vertexBuffer graphicsPipeline commandBuffer transferBuffer resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions vertexBufferBindings topIdx centerIdx |
+
+
 	
 	texWidth := 64.
 	texHeight := 64.
@@ -281,16 +273,15 @@ SDL3GraphicsPipelineTest >> test03VertexColors [
 	
 	"Upload vertex data"
 	transferBuffer := gpuDevice newUploadTransferBuffer: 3 * SDL3TestGraphicsColorVertex structureSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: vertexData to: mappedAddress size: 3 * SDL3TestGraphicsColorVertex structureSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: vertexData to: mappedAddress size: 3 * SDL3TestGraphicsColorVertex structureSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: 3 * SDL3TestGraphicsColorVertex structureSize; yourself)
-		cycle: false;
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: 3 * SDL3TestGraphicsColorVertex structureSize; yourself)
+			cycle: false ].
 
 	"2. Create Pipeline"
 	vertexBindings := FFIExternalArray externalNewType: SDL_GPUVertexBufferDescription size: 1.
@@ -319,23 +310,23 @@ SDL3GraphicsPipelineTest >> test03VertexColors [
 		format: SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
 		blendState: SDL_GPUColorTargetBlendState new.
 
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
+	graphicsPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
 		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 		vertexShader: (SDL3TestGraphicsColorVertexShaderSource newShaderAmong: shaderFormats device: gpuDevice);
 		fragmentShader: (SDL3TestGraphicsColorFragmentShaderSource newShaderAmong: shaderFormats device: gpuDevice).
-	
-	pipelineCreateInfo vertexInputState
+		
+		info vertexInputState
 		vertexBufferDescriptions: vertexBindings;
 		numVertexBuffers: 1;
 		vertexAttributes: vertexAttributes;
 		numVertexAttributes: 2.
-	
-	pipelineCreateInfo targetInfo
+		
+		info targetInfo
 		colorTargetDescriptions: colorTargetDescriptions;
 		numColorTargets: 1.
-
-	graphicsPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
+		
+	].
 
 	"3. Render"
 	colorTargetInfos := FFIArray newType: SDL_GPUColorTargetInfo size: 1.
@@ -345,56 +336,49 @@ SDL3GraphicsPipelineTest >> test03VertexColors [
 		loadOp: SDL_GPU_LOADOP_CLEAR.
 	colorTargetInfos first clearColor r: 0.0; g: 0.0; b: 0.0; a: 1.0. "Initial black"
 
-	renderPass := commandBuffer
-		 beginGPURenderPassColorTargetInfos: colorTargetInfos
-		 numColorTargets: 1
-		 depthStencilTargetInfo: nil.
-	
-	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
-	vertexBufferBindings first buffer: vertexBuffer; offset: 0.
-	
-	renderPass
-		bindGPUGraphicsPipeline: graphicsPipeline;
-		bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings numBindings: 1;
-		drawGPUPrimitivesNumVertices: 3 numInstances: 1 firstVertex: 0 firstInstance: 0;
-		end.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
+		vertexBufferBindings first buffer: vertexBuffer; offset: 0.
+		
+		renderPass
+			pipeline: graphicsPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			drawPrimitives: 3 instances: 1 firstVertex: 0 firstInstance: 0 ].
 	
 	commandBuffer submit.
 	
 	"4. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUTextureSource: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
-		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadTexture: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
+			destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"5. Assert interpolation"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
-	
-	"Top vertex is at (0, 1) in clip space -> (32, 0) in texture"
-	"Check a pixel slightly below the top vertex (32, 4) -> Should be Red"
-	topIdx := (4 * texWidth + 32) * FFIUInt32 externalTypeSize + 1.
-	self assert: (resultData at: topIdx) > 200. "Red"
-	
-	"Center (32, 32) -> Should be a mix of all colors"
-	centerIdx := (32 * texWidth + 32) * FFIUInt32 externalTypeSize + 1.
-	self assert: (resultData at: centerIdx) > 0.
-	self assert: (resultData at: centerIdx + 1) > 0.
-	self assert: (resultData at: centerIdx + 2) > 0.
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
+		
+		"Top vertex is at (0, 1) in clip space -> (32, 0) in texture"
+		"Check a pixel slightly below the top vertex (32, 4) -> Should be Red"
+		topIdx := (4 * texWidth + 32) * FFIUInt32 externalTypeSize + 1.
+		self assert: (resultData at: topIdx) > 200. "Red"
+		
+		"Center (32, 32) -> Should be a mix of all colors"
+		centerIdx := (32 * texWidth + 32) * FFIUInt32 externalTypeSize + 1.
+		self assert: (resultData at: centerIdx) > 0.
+		self assert: (resultData at: centerIdx + 1) > 0.
+		self assert: (resultData at: centerIdx + 2) > 0. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUGraphicsPipeline: graphicsPipeline.
-	gpuDevice releaseGPUBuffer: vertexBuffer.
-	gpuDevice releaseGPUTexture: colorTarget.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	graphicsPipeline release.
+	vertexBuffer release.
+	colorTarget release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -402,7 +386,9 @@ SDL3GraphicsPipelineTest >> test04GraphicsUniforms [
 	"Case 4: Uniforms
 	Draws a primitive offset by a vertex uniform with color from a fragment uniform."
 
-	| colorTarget vertexBuffer graphicsPipeline commandBuffer renderPass transferBuffer mappedAddress resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions pipelineCreateInfo vertUniforms fragUniforms vertexBufferBindings trIdx |
+	| colorTarget vertexBuffer graphicsPipeline commandBuffer transferBuffer resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions vertUniforms fragUniforms vertexBufferBindings trIdx |
+
+
 	
 	texWidth := 64.
 	texHeight := 64.
@@ -427,16 +413,14 @@ SDL3GraphicsPipelineTest >> test04GraphicsUniforms [
 	
 	"Upload vertex data"
 	transferBuffer := gpuDevice newUploadTransferBuffer: 3 * SDL3GPUQuadVertex structureSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: vertexData to: mappedAddress size: 3 * SDL3GPUQuadVertex structureSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: vertexData to: mappedAddress size: 3 * SDL3GPUQuadVertex structureSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
 		destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: 3 * SDL3GPUQuadVertex structureSize; yourself)
-		cycle: false;
-		end.
+		cycle: false ].
 
 	"2. Create Pipeline"
 	vertexBindings := FFIExternalArray externalNewType: SDL_GPUVertexBufferDescription size: 1.
@@ -458,23 +442,23 @@ SDL3GraphicsPipelineTest >> test04GraphicsUniforms [
 		format: SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
 		blendState: SDL_GPUColorTargetBlendState new.
 
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
+	graphicsPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
 		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 		vertexShader: (SDL3TestGraphicsUniformVertexShaderSource newShaderAmong: shaderFormats device: gpuDevice);
 		fragmentShader: (SDL3TestGraphicsUniformFragmentShaderSource newShaderAmong: shaderFormats device: gpuDevice).
-	
-	pipelineCreateInfo vertexInputState
+		
+		info vertexInputState
 		vertexBufferDescriptions: vertexBindings;
 		numVertexBuffers: 1;
 		vertexAttributes: vertexAttributes;
 		numVertexAttributes: 1.
-	
-	pipelineCreateInfo targetInfo
+		
+		info targetInfo
 		colorTargetDescriptions: colorTargetDescriptions;
 		numColorTargets: 1.
-
-	graphicsPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
+		
+	].
 
 	"3. Prepare Uniforms"
 	vertUniforms := SDL3TestGraphicsVertUniform new.
@@ -491,59 +475,50 @@ SDL3GraphicsPipelineTest >> test04GraphicsUniforms [
 		loadOp: SDL_GPU_LOADOP_CLEAR.
 	colorTargetInfos first clearColor r: 0.0; g: 0.0; b: 0.0; a: 1.0.
 
-	renderPass := commandBuffer
-		 beginGPURenderPassColorTargetInfos: colorTargetInfos
-		 numColorTargets: 1
-		 depthStencilTargetInfo: nil.
-	
-	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
-	vertexBufferBindings first buffer: vertexBuffer; offset: 0.
-	
-	renderPass bindGPUGraphicsPipeline: graphicsPipeline.
-	renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings numBindings: 1.
-	
-	"Push uniforms"
-	commandBuffer 
-		pushGPUVertexUniformDataSlotIndex: 0 data: vertUniforms length: SDL3TestGraphicsVertUniform structureSize;
-		pushGPUFragmentUniformDataSlotIndex: 0 data: fragUniforms length: SDL3TestGraphicsFragUniform structureSize.
-	
-	renderPass
-		drawGPUPrimitivesNumVertices: 3 numInstances: 1 firstVertex: 0 firstInstance: 0;
-		end.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
+		vertexBufferBindings first buffer: vertexBuffer; offset: 0.
+		
+		renderPass pipeline: graphicsPipeline.
+		renderPass vertexBuffers: vertexBufferBindings slot: 0.
+		
+		"Push uniforms"
+		commandBuffer 
+			pushVertexUniform: vertUniforms slot: 0;
+			pushFragmentUniform: fragUniforms slot: 0.
+		
+		renderPass drawPrimitives: 3 instances: 1 firstVertex: 0 firstInstance: 0 ].
 	
 	commandBuffer submit.
 	
 	"5. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUTextureSource: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
-		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass downloadTexture: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
+		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"6. Assert"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
-	
-	"Top-Right corner (approx 48, 16 in texture space) -> Should be Cyan (0, 255, 255, 255)"
-	"Clip space (0.5, 0.5) is (0.75, 0.25) in normalized texture space -> (48, 16) pixels"
-	trIdx := (16 * texWidth + 48) * FFIUInt32 externalTypeSize + 1.
-	self assert: (resultData at: trIdx) equals: 0. "R"
-	self assert: (resultData at: trIdx + 1) equals: 255. "G"
-	self assert: (resultData at: trIdx + 2) equals: 255. "B"
-	self assert: (resultData at: trIdx + 3) equals: 255. "A"
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
+		
+		"Top-Right corner (approx 48, 16 in texture space) -> Should be Cyan (0, 255, 255, 255)"
+		"Clip space (0.5, 0.5) is (0.75, 0.25) in normalized texture space -> (48, 16) pixels"
+		trIdx := (16 * texWidth + 48) * FFIUInt32 externalTypeSize + 1.
+		self assert: (resultData at: trIdx) equals: 0. "R"
+		self assert: (resultData at: trIdx + 1) equals: 255. "G"
+		self assert: (resultData at: trIdx + 2) equals: 255. "B"
+		self assert: (resultData at: trIdx + 3) equals: 255. "A" ].
 
 	"Cleanup"
-	gpuDevice releaseGPUGraphicsPipeline: graphicsPipeline.
-	gpuDevice releaseGPUBuffer: vertexBuffer.
-	gpuDevice releaseGPUTexture: colorTarget.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	graphicsPipeline release.
+	vertexBuffer release.
+	colorTarget release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -551,7 +526,9 @@ SDL3GraphicsPipelineTest >> test05Instancing [
 	"Case 5: Instancing
 	Draws 4 instances of a triangle using SV_InstanceID for positioning."
 
-	| colorTarget vertexBuffer graphicsPipeline commandBuffer renderPass transferBuffer mappedAddress resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions pipelineCreateInfo vertexBufferBindings |
+	| colorTarget vertexBuffer graphicsPipeline commandBuffer transferBuffer resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions vertexBufferBindings |
+
+
 	
 	texWidth := 64.
 	texHeight := 64.
@@ -576,16 +553,14 @@ SDL3GraphicsPipelineTest >> test05Instancing [
 	
 	"Upload vertex data"
 	transferBuffer := gpuDevice newUploadTransferBuffer: 3 * SDL3GPUQuadVertex structureSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: vertexData to: mappedAddress size: 3 * SDL3GPUQuadVertex structureSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: vertexData to: mappedAddress size: 3 * SDL3GPUQuadVertex structureSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
 		destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: 3 * SDL3GPUQuadVertex structureSize; yourself)
-		cycle: false;
-		end.
+		cycle: false ].
 
 	"2. Create Pipeline"
 	vertexBindings := FFIExternalArray externalNewType: SDL_GPUVertexBufferDescription size: 1.
@@ -607,23 +582,23 @@ SDL3GraphicsPipelineTest >> test05Instancing [
 		format: SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
 		blendState: SDL_GPUColorTargetBlendState new.
 
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
+	graphicsPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
 		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 		vertexShader: (SDL3TestGraphicsInstancedVertexShaderSource newShaderAmong: shaderFormats device: gpuDevice);
 		fragmentShader: (SDL3TestGraphicsInstancedFragmentShaderSource newShaderAmong: shaderFormats device: gpuDevice).
-	
-	pipelineCreateInfo vertexInputState
+		
+		info vertexInputState
 		vertexBufferDescriptions: vertexBindings;
 		numVertexBuffers: 1;
 		vertexAttributes: vertexAttributes;
 		numVertexAttributes: 1.
-	
-	pipelineCreateInfo targetInfo
+		
+		info targetInfo
 		colorTargetDescriptions: colorTargetDescriptions;
 		numColorTargets: 1.
-
-	graphicsPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
+		
+	].
 
 	"3. Render 4 instances"
 	colorTargetInfos := FFIArray newType: SDL_GPUColorTargetInfo size: 1.
@@ -633,54 +608,47 @@ SDL3GraphicsPipelineTest >> test05Instancing [
 		loadOp: SDL_GPU_LOADOP_CLEAR.
 	colorTargetInfos first clearColor r: 0.0; g: 0.0; b: 0.0; a: 1.0.
 
-	renderPass := commandBuffer
-		 beginGPURenderPassColorTargetInfos: colorTargetInfos
-		 numColorTargets: 1
-		 depthStencilTargetInfo: nil.
-	
-	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
-	vertexBufferBindings first buffer: vertexBuffer; offset: 0.
-	
-	renderPass
-		bindGPUGraphicsPipeline: graphicsPipeline;
-		bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings numBindings: 1;
-		drawGPUPrimitivesNumVertices: 3 numInstances: 4 firstVertex: 0 firstInstance: 0;
-		end.
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass |
+		vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
+		vertexBufferBindings first buffer: vertexBuffer; offset: 0.
+		
+		renderPass
+			pipeline: graphicsPipeline;
+			vertexBuffers: vertexBufferBindings slot: 0;
+			drawPrimitives: 3 instances: 4 firstVertex: 0 firstInstance: 0 ].
 	
 	commandBuffer submit.
 	
 	"4. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUTextureSource: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
-		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			downloadTexture: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
+			destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"5. Assert multiple instances are drawn (White pixels in each quadrant)"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
-	
-	"Bottom-Left (approx 16, 48) - ID 0"
-	self assert: (resultData at: (48 * texWidth + 16) * FFIUInt32 externalTypeSize + 1) equals: 255.
-	"Bottom-Right (approx 48, 48) - ID 1"
-	self assert: (resultData at: (48 * texWidth + 48) * FFIUInt32 externalTypeSize + 1) equals: 255.
-	"Top-Left (approx 16, 16) - ID 2"
-	self assert: (resultData at: (16 * texWidth + 16) * FFIUInt32 externalTypeSize + 1) equals: 255.
-	"Top-Right (approx 48, 16) - ID 3"
-	self assert: (resultData at: (16 * texWidth + 48) * FFIUInt32 externalTypeSize + 1) equals: 255.
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
+		
+		"Bottom-Left (approx 16, 48) - ID 0"
+		self assert: (resultData at: (48 * texWidth + 16) * FFIUInt32 externalTypeSize + 1) equals: 255.
+		"Bottom-Right (approx 48, 48) - ID 1"
+		self assert: (resultData at: (48 * texWidth + 48) * FFIUInt32 externalTypeSize + 1) equals: 255.
+		"Top-Left (approx 16, 16) - ID 2"
+		self assert: (resultData at: (16 * texWidth + 16) * FFIUInt32 externalTypeSize + 1) equals: 255.
+		"Top-Right (approx 48, 16) - ID 3"
+		self assert: (resultData at: (16 * texWidth + 48) * FFIUInt32 externalTypeSize + 1) equals: 255. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUGraphicsPipeline: graphicsPipeline.
-	gpuDevice releaseGPUBuffer: vertexBuffer.
-	gpuDevice releaseGPUTexture: colorTarget.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	graphicsPipeline release.
+	vertexBuffer release.
+	colorTarget release.
+	transferBuffer release
 ]
 
 { #category : 'tests' }
@@ -689,7 +657,9 @@ SDL3GraphicsPipelineTest >> test06DepthTesting [
 	Draws a near Blue quad first, then a far Red quad.
 	With depth testing enabled (LESS), the Red quad should be rejected."
 
-	| colorTarget depthTarget vertexBuffer graphicsPipeline commandBuffer renderPass transferBuffer mappedAddress resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions pipelineCreateInfo blueUniforms redUniforms depthStencilTargetInfo vertexBufferBindings |
+	| colorTarget depthTarget vertexBuffer graphicsPipeline commandBuffer transferBuffer resultData texWidth texHeight byteSize colorTargetInfos vertexData vertexBindings vertexAttributes colorTargetDescriptions blueUniforms redUniforms depthStencilTargetInfo vertexBufferBindings |
+
+
 	
 	texWidth := 64.
 	texHeight := 64.
@@ -723,16 +693,15 @@ SDL3GraphicsPipelineTest >> test06DepthTesting [
 	
 	"Upload vertex data"
 	transferBuffer := gpuDevice newUploadTransferBuffer: 6 * SDL3GPUQuadVertex structureSize.
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	LibC memCopy: vertexData to: mappedAddress size: 6 * SDL3GPUQuadVertex structureSize.
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		LibC memCopy: vertexData to: mappedAddress size: 6 * SDL3GPUQuadVertex structureSize. ].
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		uploadToGPUBufferSource: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
-		destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: 6 * SDL3GPUQuadVertex structureSize; yourself)
-		cycle: false;
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadBuffer: (SDL_GPUTransferBufferLocation new transferBuffer: transferBuffer; offset: 0; yourself)
+			destination: (SDL_GPUBufferRegion new buffer: vertexBuffer; offset: 0; size: 6 * SDL3GPUQuadVertex structureSize; yourself)
+			cycle: false ].
 
 	"2. Create Pipeline with Depth Testing"
 	vertexBindings := FFIExternalArray externalNewType: SDL_GPUVertexBufferDescription size: 1.
@@ -754,31 +723,31 @@ SDL3GraphicsPipelineTest >> test06DepthTesting [
 		format: SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
 		blendState: SDL_GPUColorTargetBlendState new.
 
-	pipelineCreateInfo := SDL_GPUGraphicsPipelineCreateInfo new.
-	pipelineCreateInfo
+	graphicsPipeline := gpuDevice newGraphicsPipeline: [ :info |
+		info
 		primitiveType: SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 		vertexShader: (SDL3TestGraphicsDepthVertexShaderSource newShaderAmong: shaderFormats device: gpuDevice);
 		fragmentShader: (SDL3TestGraphicsDepthFragmentShaderSource newShaderAmong: shaderFormats device: gpuDevice).
-	
-	pipelineCreateInfo vertexInputState
+		
+		info vertexInputState
 		vertexBufferDescriptions: vertexBindings;
 		numVertexBuffers: 1;
 		vertexAttributes: vertexAttributes;
 		numVertexAttributes: 1.
-	
-	pipelineCreateInfo targetInfo
+		
+		info targetInfo
 		colorTargetDescriptions: colorTargetDescriptions;
 		numColorTargets: 1;
 		depthStencilFormat: SDL_GPU_TEXTUREFORMAT_D16_UNORM;
 		hasDepthStencilTarget: true.
 		
-	pipelineCreateInfo depthStencilState: (SDL_GPUDepthStencilState new 
+		info depthStencilState: (SDL_GPUDepthStencilState new 
 			enableDepthTest: true;
 			enableDepthWrite: true;
 			compareOp: SDL_GPU_COMPAREOP_LESS;
 			yourself).
-
-	graphicsPipeline := gpuDevice newGPUGraphicsPipelineCreateinfo: pipelineCreateInfo.
+		
+	].
 
 	"3. Prepare Uniforms"
 	blueUniforms := SDL3TestGraphicsFragUniform new r: 0.0; g: 0.0; b: 1.0; a: 1.0. "Near Blue"
@@ -800,58 +769,50 @@ SDL3GraphicsPipelineTest >> test06DepthTesting [
 		cycle: false.
 	depthStencilTargetInfo clearDepth: 1.0.
 
-	renderPass := commandBuffer
-		 beginGPURenderPassColorTargetInfos: colorTargetInfos
-		 numColorTargets: 1
-		 depthStencilTargetInfo: depthStencilTargetInfo.
+	commandBuffer renderPassTargets: colorTargetInfos depthStencil: depthStencilTargetInfo do: [ :renderPass |
+		vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
+		vertexBufferBindings first buffer: vertexBuffer; offset: 0.
+		
+		renderPass pipeline: graphicsPipeline.
+		renderPass vertexBuffers: vertexBufferBindings slot: 0.
+		
+		"A. Draw Blue at z=0.0"
+		commandBuffer pushVertexUniform: (SDL3TestGraphicsVertUniform new x: 0.0; y: 0.0; z: 0.0) slot: 0.
+		commandBuffer pushFragmentUniform: blueUniforms slot: 0.
+		renderPass drawPrimitives: 6 instances: 1 firstVertex: 0 firstInstance: 0.
+		
+		"B. Draw Red at z=1.0"
+		commandBuffer pushVertexUniform: (SDL3TestGraphicsVertUniform new x: 0.0; y: 0.0; z: 1.0) slot: 0.
+		commandBuffer pushFragmentUniform: redUniforms slot: 0.
+		renderPass drawPrimitives: 6 instances: 1 firstVertex: 0 firstInstance: 0 ].
 	
-	vertexBufferBindings := FFIArray newType: SDL_GPUBufferBinding size: 1.
-	vertexBufferBindings first buffer: vertexBuffer; offset: 0.
-	
-	renderPass bindGPUGraphicsPipeline: graphicsPipeline.
-	renderPass bindGPUVertexBuffersFirstSlot: 0 bindings: vertexBufferBindings numBindings: 1.
-	
-	"A. Draw Blue at z=0.0"
-	commandBuffer pushGPUVertexUniformDataSlotIndex: 0 data: (SDL3TestGraphicsVertUniform new x: 0.0; y: 0.0; z: 0.0) length: SDL3TestGraphicsVertUniform structureSize.
-	commandBuffer pushGPUFragmentUniformDataSlotIndex: 0 data: blueUniforms length: SDL3TestGraphicsFragUniform structureSize.
-	renderPass drawGPUPrimitivesNumVertices: 6 numInstances: 1 firstVertex: 0 firstInstance: 0.
-
-	"B. Draw Red at z=1.0"
-	commandBuffer pushGPUVertexUniformDataSlotIndex: 0 data: (SDL3TestGraphicsVertUniform new x: 0.0; y: 0.0; z: 1.0) length: SDL3TestGraphicsVertUniform structureSize.
-	commandBuffer pushGPUFragmentUniformDataSlotIndex: 0 data: redUniforms length: SDL3TestGraphicsFragUniform structureSize.
-	renderPass drawGPUPrimitivesNumVertices: 6 numInstances: 1 firstVertex: 0 firstInstance: 0.
-
-	renderPass end.
 	commandBuffer submit.
 	
 	"5. Download results"
-	gpuDevice releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	transferBuffer := gpuDevice newDownloadTransferBuffer: byteSize.
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
-	commandBuffer beginGPUCopyPass
-		downloadFromGPUTextureSource: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
-		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself);
-		end.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass downloadTexture: (SDL3GPUTextureRegion new texture: colorTarget; w: texWidth; h: texHeight; d: 1; yourself)
+		destination: (SDL3GPUTextureTransferInfo new transferBuffer: transferBuffer; offset: 0; yourself) ].
 	commandBuffer submit.
 
 	gpuDevice waitForGPUIdle.
 
 	"6. Assert result is Blue (0, 0, 255, 255) because Red was rejected"
-	mappedAddress := gpuDevice mapGPUTransferBuffer: transferBuffer cycle: false.
-	resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
-	
-	{ 1 . (byteSize // 2) + 1 . (byteSize - 3) } do: [ :baseIdx |
+	gpuDevice mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		resultData := FFIArray fromHandle: mappedAddress type: FFIUInt8 size: byteSize.
+		
+		{ 1 . (byteSize // 2) + 1 . (byteSize - 3) } do: [ :baseIdx |
 		self assert: (resultData at: baseIdx) equals: 0. "R"
 		self assert: (resultData at: baseIdx + 1) equals: 0. "G"
 		self assert: (resultData at: baseIdx + 2) equals: 255. "B"
-		self assert: (resultData at: baseIdx + 3) equals: 255. "A" ].
-
-	gpuDevice unmapGPUTransferBuffer: transferBuffer.
+		self assert: (resultData at: baseIdx + 3) equals: 255. "A" ]. ].
 
 	"Cleanup"
-	gpuDevice releaseGPUGraphicsPipeline: graphicsPipeline.
-	gpuDevice releaseGPUBuffer: vertexBuffer.
-	gpuDevice releaseGPUTexture: colorTarget.
-	gpuDevice releaseGPUTexture: depthTarget.
-	gpuDevice releaseGPUTransferBuffer: transferBuffer
+	graphicsPipeline release.
+	vertexBuffer release.
+	colorTarget release.
+	depthTarget release.
+	transferBuffer release
 ]

--- a/src/SDL3-OSWindow/OSSDL3FormRenderer.class.st
+++ b/src/SDL3-OSWindow/OSSDL3FormRenderer.class.st
@@ -53,8 +53,8 @@ OSSDL3FormRenderer >> createTexture [
 		sdlRenderer
 			newTextureFormat: SDL_PIXELFORMAT_XRGB8888
 			access: SDL_TEXTUREACCESS_STREAMING
-			w: formExtent x
-			h: formExtent y
+			width: formExtent x
+			height: formExtent y
 ]
 
 { #category : 'morphic integration' }

--- a/src/SDL3-OSWindow/OSSDL3GPUFormRenderer.class.st
+++ b/src/SDL3-OSWindow/OSSDL3GPUFormRenderer.class.st
@@ -16,8 +16,7 @@ Class {
 		'deferFlush',
 		'uploadStream',
 		'swapchainWidthHolder',
-		'swapchainHeightHolder',
-		'blitInfo'
+		'swapchainHeightHolder'
 	],
 	#pools : [
 		'SDL3AllEnumerations'
@@ -43,7 +42,7 @@ OSSDL3GPUFormRenderer >> destroy [
 
 	mutex critical: [
 		gpuTexture ifNotNil: [
-			gpuDevice releaseGPUTexture: gpuTexture.
+			gpuTexture release.
 			gpuTexture := nil ].
 		
 		uploadStream ifNotNil: [ 
@@ -64,28 +63,25 @@ OSSDL3GPUFormRenderer >> flush [
 		"Try to Acquire Swapchain texture (Non-blocking)."
 		commandBuffer := gpuDevice acquireGPUCommandBuffer.
 		commandBuffer
-			acquireGPUSwapchainTextureForWindow: backendWindow sdlWindow
-			into: swapchainTextureHolder 
-			width: swapchainWidthHolder 
+			acquireSwapchainTextureForWindow: backendWindow sdlWindow
+			into: swapchainTextureHolder
+			width: swapchainWidthHolder
 			height: swapchainHeightHolder.
 
 		"If swapchain is not available submit the empty command buffer and retry later"
-		[	swapchainTextureHolder value isNull ifFalse: [ 
+		[	swapchainTextureHolder value isNull ifFalse: [
 
-				blitInfo source 
-					texture: gpuTexture;
-					w: extent x;
-					h: extent y.
-					
-				blitInfo destination 
-					texture: swapchainTextureHolder value;
-					w: swapchainWidthHolder value;
-					h: swapchainHeightHolder value.
-					
-				blitInfo loadOp: SDL_GPU_LOADOP_DONT_CARE.
-				blitInfo filter: SDL_GPU_FILTER_LINEAR.
-
-				commandBuffer blitGPUTextureInfo: blitInfo.
+				commandBuffer blitFrom: gpuTexture to: swapchainTextureHolder value do: [ :blitInfo |
+					blitInfo source 
+						w: extent x;
+						h: extent y.
+						
+					blitInfo destination 
+						w: swapchainWidthHolder value;
+						h: swapchainHeightHolder value.
+						
+					blitInfo loadOp: SDL_GPU_LOADOP_DONT_CARE;
+						filter: SDL_GPU_FILTER_LINEAR ].
 
 				needsFlush := false ]
 
@@ -107,7 +103,7 @@ OSSDL3GPUFormRenderer >> initializeGPUResources [
 
 	extent := form extent.
 
-	gpuTexture ifNotNil: [ gpuDevice releaseGPUTexture: gpuTexture ].
+	gpuTexture ifNotNil: [ gpuTexture release ].
 	
 	uploadStream ifNil: [
 		uploadStream := OSSDL3GPUUploadStream new ].
@@ -121,9 +117,6 @@ OSSDL3GPUFormRenderer >> initializeGPUResources [
 		height: extent y.
 
 	"Pre-allocate to avoid GC pressure in hot path"
-	blitInfo := SDL3GPUBlitInfo externalNew.
-	blitInfo autoRelease.
-
 	swapchainTextureHolder := (FFIExternalValueHolder ofType: SDL_GPUTexture) new.
 	swapchainWidthHolder := FFIUInt32 newValueHolder.
 	swapchainHeightHolder := FFIUInt32 newValueHolder

--- a/src/SDL3-OSWindow/OSSDL3GPUUploadStream.class.st
+++ b/src/SDL3-OSWindow/OSSDL3GPUUploadStream.class.st
@@ -86,7 +86,7 @@ OSSDL3GPUUploadStream >> destroy [
 	"Release the GPU transfer buffer and the VM surface"
 
 	transferBuffer ifNotNil: [ 
-		gpuDevice releaseGPUTransferBuffer: transferBuffer.
+		transferBuffer release.
 		transferBuffer := nil ].
 	
 	externalForm ifNotNil: [ 
@@ -105,7 +105,7 @@ OSSDL3GPUUploadStream >> ensureBatchStarted [
 
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
 
-	copyPass := commandBuffer beginGPUCopyPass.
+	copyPass := commandBuffer beginCopyPass.
 	currentOffset := 0
 ]
 
@@ -223,7 +223,7 @@ OSSDL3GPUUploadStream >> uploadForm: aForm region: aRectangle to: aTexture at: a
 		x: aPoint x; y: aPoint y;
 		w: aRectangle width; h: aRectangle height.
 
-	copyPass uploadToGPUTextureSource: transferInfo destination: textureRegion cycle: false.
+	copyPass uploadTexture: transferInfo destination: textureRegion cycle: false.
 
 	"5. Advance offset for next item in the stream"
 	currentOffset := currentOffset + bytesNeeded

--- a/src/SDL3-Own/ExternalAddress.extension.st
+++ b/src/SDL3-Own/ExternalAddress.extension.st
@@ -61,3 +61,11 @@ ExternalAddress >> readStructArrayFromPointers: aFFIStructure size: count [
 			stream nextPut: (aFFIStructure fromHandle: (address pointerAt: 1)).
 			address := address + FFIExternalType pointerSize ] ]
 ]
+
+{ #category : '*SDL3-Own' }
+ExternalAddress class >> safeNewArray: anInteger [
+
+	^ (FFIExternalArray externalNewType: self size: anInteger)
+		autoRelease;
+		yourself
+]

--- a/src/SDL3-Own/SDL3Color.extension.st
+++ b/src/SDL3-Own/SDL3Color.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'SDL3Color' }
+
+{ #category : '*SDL3-Own' }
+SDL3Color >> beR: r g: g b: b a: a [
+
+	self
+		r: r;
+		g: g;
+		b: b;
+		a: a
+]

--- a/src/SDL3-Own/SDL3ComputeShaderSource.class.st
+++ b/src/SDL3-Own/SDL3ComputeShaderSource.class.st
@@ -61,7 +61,12 @@ SDL3ComputeShaderSource class >> newComputePipelineAmong: supportedShaderFormats
 				threadcountY: self threadCountY;
 				threadcountZ: self threadCountZ.
 
-			computePipeline := aSDL3GPUDevice newGPUComputePipelineCreateinfo: createInfo.
+			computePipeline := (aSDL3GPUDevice ffiLibrary
+				newGPUComputePipelineDevice: aSDL3GPUDevice
+				createinfo: createInfo)
+					assertNotNullReturn;
+					device: aSDL3GPUDevice;
+					yourself.
 			^ computePipeline ]
 ]
 

--- a/src/SDL3-Own/SDL3GPUBlitInfo.extension.st
+++ b/src/SDL3-Own/SDL3GPUBlitInfo.extension.st
@@ -1,6 +1,26 @@
 Extension { #name : 'SDL3GPUBlitInfo' }
 
 { #category : '*SDL3-Own' }
+SDL3GPUBlitInfo >> beSource: sourceTexture destination: destinationTexture filter: aFilter [
+
+	self
+		loadOp: SDL3GPULoadOp dontCare;
+		flipMode: SDL3FlipMode none;
+		filter: aFilter;
+		cycle: false.
+	self source beTexture: sourceTexture.
+	self destination beTexture: destinationTexture
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUBlitInfo class >> source: sourceTexture destination: destinationTexture filter: aFilter [
+
+	^ self safeNew
+		beSource: sourceTexture destination: destinationTexture filter: aFilter;
+		yourself
+]
+
+{ #category : '*SDL3-Own' }
 SDL3GPUBlitInfo >> updateClearColorFrom: aColor [
 
 	self clearColor updateFrom: aColor

--- a/src/SDL3-Own/SDL3GPUBlitRegion.extension.st
+++ b/src/SDL3-Own/SDL3GPUBlitRegion.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : 'SDL3GPUBlitRegion' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUBlitRegion >> beTexture: aTexture [
+
+	self
+		texture: aTexture;
+		mipLevel: 0;
+		layerOrDepthPlane: 0;
+		x: 0;
+		y: 0;
+		w: 0;
+		h: 0
+]

--- a/src/SDL3-Own/SDL3GPUBufferBinding.extension.st
+++ b/src/SDL3-Own/SDL3GPUBufferBinding.extension.st
@@ -1,6 +1,34 @@
 Extension { #name : 'SDL3GPUBufferBinding' }
 
 { #category : '*SDL3-Own' }
+SDL3GPUBufferBinding >> beBuffer: aBuffer offset: anInteger [
+
+	self
+		buffer: aBuffer;
+		offset: anInteger
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUBufferBinding >> beOffset: anInteger [
+
+	self beBuffer: ExternalAddress null offset: anInteger
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUBufferBinding class >> buffer: aBuffer offset: anInteger [
+
+	^ self safeNew
+		beBuffer: aBuffer offset: anInteger;
+		yourself
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUBufferBinding class >> offset: anInteger [
+
+	^ self buffer: ExternalAddress null offset: anInteger
+]
+
+{ #category : '*SDL3-Own' }
 SDL3GPUBufferBinding >> printOn: aStream [
 
 	super printOn: aStream.

--- a/src/SDL3-Own/SDL3GPUColorTargetInfo.extension.st
+++ b/src/SDL3-Own/SDL3GPUColorTargetInfo.extension.st
@@ -1,6 +1,83 @@
 Extension { #name : 'SDL3GPUColorTargetInfo' }
 
 { #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo >> beClear [
+
+	self beClear: Color black
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo >> beClear: aColor [
+
+	self beClearTexture: ExternalAddress null color: aColor
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo >> beClearTexture: aTexture [
+
+	self beClearTexture: aTexture color: Color black
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo >> beClearTexture: aTexture color: aColor [
+
+	self
+		texture: aTexture;
+		mipLevel: 0;
+		layerOrDepthPlane: 0;
+		loadOp: SDL3GPULoadOp clear;
+		storeOp: SDL3GPUStoreOp store;
+		cycle: false.
+	self updateClearColorFrom: aColor
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo >> beLoad [
+
+	self beLoad: ExternalAddress null
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo >> beLoad: aTexture [
+
+	self
+		texture: aTexture;
+		mipLevel: 0;
+		layerOrDepthPlane: 0;
+		loadOp: SDL3GPULoadOp load;
+		storeOp: SDL3GPUStoreOp store;
+		cycle: false
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo class >> clear [
+
+	^ self clear: Color black
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo class >> clear: aColor [
+
+	^ self safeNew
+		beClear: aColor;
+		yourself
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo class >> load [
+
+	^ self load: ExternalAddress null
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUColorTargetInfo class >> load: aTexture [
+
+	^ self safeNew
+		beLoad: aTexture;
+		yourself
+]
+
+{ #category : '*SDL3-Own' }
 SDL3GPUColorTargetInfo >> updateClearColorFrom: aColor [
 
 	self clearColor updateFrom: aColor

--- a/src/SDL3-Own/SDL3GPUCommandBuffer.extension.st
+++ b/src/SDL3-Own/SDL3GPUCommandBuffer.extension.st
@@ -1,20 +1,105 @@
 Extension { #name : 'SDL3GPUCommandBuffer' }
 
 { #category : '*SDL3-Own' }
-SDL3GPUCommandBuffer >> beginGPUComputePassStorageTextureBindings: storageTextureBindings storageBufferBindings: storageBufferBindings [
+SDL3GPUCommandBuffer >> beginComputePassTextures: storageTextureBindings storageBuffers: storageBuffers [
 
 	^ self
-		 beginGPUComputePassStorageTextureBindings: (storageTextureBindings ifEmpty: [ ExternalAddress null ])
-		 numStorageTextureBindings: storageTextureBindings size
-		 storageBufferBindings: (storageBufferBindings ifEmpty: [ ExternalAddress null ])
-		 numStorageBufferBindings: storageBufferBindings size
+		 beginComputePassTextures: (storageTextureBindings ifEmpty: [ ExternalAddress null ])
+		 count: storageTextureBindings size
+		 storageBuffers: (storageBuffers ifEmpty: [ ExternalAddress null ])
+		 count: storageBuffers size
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPUCommandBuffer >> beginGPURenderPassColorTargetInfos: colorTargetInfos depthStencilTargetInfo: depthStencilTargetInfo [
+SDL3GPUCommandBuffer >> beginRenderPassTargets: colorTargetInfos [
+
+	^ self beginRenderPassTargets: colorTargetInfos depthStencil: nil
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> beginRenderPassTargets: colorTargetInfos depthStencil: depthStencilTargetInfo [
 
 	^ self
-		 beginGPURenderPassColorTargetInfos: (colorTargetInfos ifEmpty: [ ExternalAddress null ])
-		 numColorTargets: colorTargetInfos size
-		 depthStencilTargetInfo: depthStencilTargetInfo
+		 beginRenderPassTargets: (colorTargetInfos ifEmpty: [ ExternalAddress null ])
+		 count: colorTargetInfos size
+		 depthStencil: depthStencilTargetInfo
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> blitFrom: sourceTexture to: destinationTexture do: aBlock [
+
+	| info |
+	info := SDL3GPUBlitInfo externalNew.
+	[ 
+	info
+		beSource: sourceTexture
+		destination: destinationTexture
+		filter: SDL3GPUFilter linear.
+	aBlock value: info.
+	^ self blit: info ] ensure: [ info free ]
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> computePassTextures: texArray computeStorageBuffers: bufArray do: aBlock [
+
+	| pass |
+	pass := self beginComputePassTextures: texArray storageBuffers: bufArray.
+	[ aBlock value: pass ] ensure: [ pass end ]
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> copyPassDo: aBlock [
+
+	| pass |
+	pass := self beginCopyPass.
+	[ aBlock value: pass ] ensure: [ pass end ]
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> pushComputeUniform: data slot: slot [
+
+	^ self
+		  pushComputeUniformSlot: slot
+		  data: data
+		  length: data class structureSize
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> pushFragmentUniform: data slot: slot [
+
+	^ self
+		  pushFragmentUniformSlot: slot
+		  data: data
+		  length: data class structureSize
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> pushVertexUniform: data slot: slot [
+
+	^ self
+		  pushVertexUniformSlot: slot
+		  data: data
+		  length: data class structureSize
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> renderPassTargets: targetArray depthStencil: depthInfo do: aBlock [
+
+	| pass |
+	pass := self beginRenderPassTargets: targetArray depthStencil: depthInfo.
+	[ aBlock value: pass ] ensure: [ pass end ]
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> renderPassTargets: targetArray do: aBlock [
+
+	self renderPassTargets: targetArray depthStencil: nil do: aBlock
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUCommandBuffer >> uploadToGPUDo: aBlock [
+	"Yields an uploader using an already active copy pass on this command buffer."
+
+	self copyPassDo: [ :copyPass |
+		SDL3GPUUploader on: self device copyPass: copyPass do: aBlock ]
 ]

--- a/src/SDL3-Own/SDL3GPUComputePass.extension.st
+++ b/src/SDL3-Own/SDL3GPUComputePass.extension.st
@@ -1,28 +1,28 @@
 Extension { #name : 'SDL3GPUComputePass' }
 
 { #category : '*SDL3-Own' }
-SDL3GPUComputePass >> bindGPUComputeSamplersFirstSlot: firstSlot textureSamplerBindings: textureSamplerBindings [
+SDL3GPUComputePass >> computeSamplers: textureSamplerBindings slot: firstSlot [
 
 	^ self
-		 bindGPUComputeSamplersFirstSlot: firstSlot
-		 textureSamplerBindings: (textureSamplerBindings ifEmpty: [ ExternalAddress null ])
-		 numBindings: textureSamplerBindings size
+		 computeSamplersSlot: firstSlot
+		 bindings: (textureSamplerBindings ifEmpty: [ ExternalAddress null ])
+		 count: textureSamplerBindings size
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPUComputePass >> bindGPUComputeStorageBuffersFirstSlot: firstSlot storageBuffers: storageBuffers [
+SDL3GPUComputePass >> computeStorageBuffers: storageBuffers slot: firstSlot [
 
 	^ self
-		 bindGPUComputeStorageBuffersFirstSlot: firstSlot
-		 storageBuffers: (storageBuffers ifEmpty: [ ExternalAddress null ])
-		 numBindings: storageBuffers size
+		 computeStorageBuffersSlot: firstSlot
+		 bindings: (storageBuffers ifEmpty: [ ExternalAddress null ])
+		 count: storageBuffers size
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPUComputePass >> bindGPUComputeStorageTexturesFirstSlot: firstSlot storageTextures: storageTextures [
+SDL3GPUComputePass >> computeStorageTextures: storageTextures slot: firstSlot [
 
 	^ self
-		 bindGPUComputeStorageTexturesFirstSlot: firstSlot
-		 storageTextures: (storageTextures ifEmpty: [ ExternalAddress null ])
-		 numBindings: storageTextures size
+		 computeStorageTexturesSlot: firstSlot
+		 bindings: (storageTextures ifEmpty: [ ExternalAddress null ])
+		 count: storageTextures size
 ]

--- a/src/SDL3-Own/SDL3GPUComputePipelineCreateInfo.extension.st
+++ b/src/SDL3-Own/SDL3GPUComputePipelineCreateInfo.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : 'SDL3GPUComputePipelineCreateInfo' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUComputePipelineCreateInfo >> shader: aShader textures: t buffers: b [
+	"Populate format, code, and entrypoint from a shader, and set counts."
+	self
+		format: aShader format;
+		code: aShader code;
+		codeSize: aShader codeSize;
+		entrypoint: aShader entrypoint;
+		numReadwriteStorageTextures: t;
+		numReadwriteStorageBuffers: b
+]

--- a/src/SDL3-Own/SDL3GPUDepthStencilTargetInfo.extension.st
+++ b/src/SDL3-Own/SDL3GPUDepthStencilTargetInfo.extension.st
@@ -1,0 +1,34 @@
+Extension { #name : 'SDL3GPUDepthStencilTargetInfo' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDepthStencilTargetInfo >> beClear [
+
+	self beClear: ExternalAddress null
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDepthStencilTargetInfo >> beClear: aTexture [
+
+	self
+		texture: aTexture;
+		mipLevel: 0;
+		layer: 0;
+		loadOp: SDL3GPULoadOp clear;
+		storeOp: SDL3GPUStoreOp dontCare;
+		cycle: false.
+	self clearDepth: 1.0
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDepthStencilTargetInfo class >> clear [
+
+	^ self clear: ExternalAddress null
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDepthStencilTargetInfo class >> clear: aTexture [
+
+	^ self safeNew
+		beClear: aTexture;
+		yourself
+]

--- a/src/SDL3-Own/SDL3GPUDevice.extension.st
+++ b/src/SDL3-Own/SDL3GPUDevice.extension.st
@@ -1,6 +1,44 @@
 Extension { #name : 'SDL3GPUDevice' }
 
 { #category : '*SDL3-Own' }
+SDL3GPUDevice >> downloadFrom: sourceBuffer type: ffiClass count: arraySize do: aBlock [
+	"Synchronously downloads data from a GPU buffer to the CPU, stalling the CPU until complete."
+
+	| byteSize transferBuffer commandBuffer |
+	byteSize := ffiClass externalTypeSize * arraySize.
+	transferBuffer := self newDownloadTransferBuffer: byteSize.
+	
+	[
+		"1. Record and submit the copy command"
+		commandBuffer := self acquireGPUCommandBuffer.
+		commandBuffer copyPassDo: [ :copyPass |
+			copyPass
+				downloadBuffer:
+					(SDL_GPUBufferRegion new
+						buffer: sourceBuffer;
+						offset: 0;
+						size: byteSize;
+						yourself)
+				destination:
+					(SDL_GPUTransferBufferLocation new
+						transferBuffer: transferBuffer;
+						offset: 0;
+						yourself) ].
+		commandBuffer submit.
+
+		"2. Stall CPU until the transfer is physically complete on the GPU"
+		self waitForGPUIdle.
+
+		"3. Map memory and let the user read it"
+		self mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+			| array |
+			array := FFIArray fromHandle: mappedAddress type: ffiClass size: arraySize.
+			aBlock value: array ]
+			
+	] ensure: [ transferBuffer release ]
+]
+
+{ #category : '*SDL3-Own' }
 SDL3GPUDevice >> gpuShaderFormatsAsArray [
 
 	| formatsBitFlags |
@@ -12,52 +50,84 @@ SDL3GPUDevice >> gpuShaderFormatsAsArray [
 ]
 
 { #category : '*SDL3-Own' }
+SDL3GPUDevice >> mapTransferBuffer: transferBuffer cycle: cycle do: aBlock [
+
+	| address |
+	address := self mapGPUTransferBuffer: transferBuffer cycle: cycle.
+	address isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
+	[ aBlock value: address ] ensure: [ self unmapGPUTransferBuffer: transferBuffer ]
+]
+
+{ #category : '*SDL3-Own' }
 SDL3GPUDevice >> new2DGPUTextureFormat: pixelFormat usage: usage width: width height: height [
 	"Answer a new `SDL_GPUTexture` with the given pixel format, usage and extent, and use default values."
 
-	| createinfo |
-	createinfo := SDL_GPUTextureCreateInfo new.
-	createinfo
-		type: SDL_GPU_TEXTURETYPE_2D;
-		format: pixelFormat;
-		usage: usage asInteger;
-		width: width;
-		height: height;
-		layerCountOrDepth: 1;
-		numLevels: 1;
-		sampleCount: SDL_GPU_SAMPLECOUNT_1;
-		props: 0.
+	^ self newTexture: [ :info |
+		info
+			type: SDL_GPU_TEXTURETYPE_2D;
+			format: pixelFormat;
+			usage: usage asInteger;
+			width: width;
+			height: height;
+			layerCountOrDepth: 1;
+			numLevels: 1;
+			sampleCount: SDL_GPU_SAMPLECOUNT_1;
+			props: 0 ]
+]
 
-	^ self newGPUTextureCreateinfo: createinfo
+{ #category : '*SDL3-Own' }
+SDL3GPUDevice >> newBuffer: aBlock [
+
+	| info |
+	info := SDL3GPUBufferCreateInfo externalNew.
+	^ [ 
+		aBlock value: info.
+		(self ffiLibrary newGPUBufferDevice: self createinfo: info)
+			assertNotNullReturn;
+			device: self;
+			yourself
+	] ensure: [ info free ]
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDevice >> newComputePipeline: aBlock [
+
+	| createInfo |
+	createInfo := SDL3GPUComputePipelineCreateInfo externalNew.
+	^ [
+		aBlock value: createInfo.
+		(self ffiLibrary newGPUComputePipelineDevice: self createinfo: createInfo)
+			assertNotNullReturn;
+			device: self;
+			yourself
+	] ensure: [ createInfo free ]
 ]
 
 { #category : '*SDL3-Own' }
 SDL3GPUDevice >> newDownloadTransferBuffer: size [
 	"Create a transfer buffer for downloading data from the GPU."
 
-	| createinfo transferBuffer |
-	createinfo := SDL3GPUTransferBufferCreateInfo new.
-	createinfo
-		usage: SDL3GPUTransferBufferUsage download;
-		size: size;
-		props: 0.
-
-	transferBuffer := self newGPUTransferBufferCreateinfo: createinfo.
-	^ transferBuffer
+	| info |
+	info := SDL3GPUTransferBufferCreateInfo externalNew.
+	^ [
+		info
+			usage: SDL3GPUTransferBufferUsage download;
+			size: size;
+			props: 0.
+		(self ffiLibrary newGPUTransferBufferDevice: self createinfo: info)
+			assertNotNullReturn;
+			device: self;
+			yourself
+	] ensure: [ info free ]
 ]
 
 { #category : '*SDL3-Own' }
 SDL3GPUDevice >> newGPUBufferUsage: usage size: size [
 
-	| createInfo gpuBuffer |
-	createInfo :=
-		SDL_GPUBufferCreateInfo new 
+	^ self newBuffer: [ :info |
+		info
 			usage: usage asInteger;
-			size: size;
-			yourself.
-
-	gpuBuffer := self newGPUBufferCreateinfo: createInfo.
-	^ gpuBuffer
+			size: size ]
 ]
 
 { #category : '*SDL3-Own' }
@@ -65,7 +135,9 @@ SDL3GPUDevice >> newGPUTextureUploadingForm: aForm usage: aUsage [
 	"Answer a new `SDL_GPUTexture` and copy the Form pixels to it (assuming depth is 32 bits).
 	Sender is responsible of releasing the texture. Note: It may be convenient to reuse the transfer buffer and other SDL objects."
 
-	| gpuTexture transferBuffer mappedAddress commandBuffer copyPass |
+	| gpuTexture transferBuffer commandBuffer |
+
+
 	self assert: [ aForm depth = 32 ].
 	aForm unhibernate.
 
@@ -77,50 +149,91 @@ SDL3GPUDevice >> newGPUTextureUploadingForm: aForm usage: aUsage [
 			height: aForm height.
 
 	transferBuffer := self newUploadTransferBuffer: aForm bits byteSize.
-	mappedAddress := self mapGPUTransferBuffer: transferBuffer cycle: false.
-	mappedAddress isNull ifTrue: [ SDL3Error signalFromLibraryErrorMessage ].
-
-	"Copy from surface pixels handle to mappedAddress handle"
-	LibC memCopy: aForm bits to: mappedAddress size: aForm bits byteSize.
-	self unmapGPUTransferBuffer: transferBuffer.
+	self mapTransferBuffer: transferBuffer cycle: false do: [ :mappedAddress |
+		"Copy from surface pixels handle to mappedAddress handle"
+		LibC memCopy: aForm bits to: mappedAddress size: aForm bits byteSize ].
 
 	commandBuffer := self acquireGPUCommandBuffer.
-	copyPass := commandBuffer beginGPUCopyPass.
-	copyPass
-		uploadToGPUTextureSource:
-			(SDL_GPUTextureTransferInfo new
-				transferBuffer: transferBuffer;
-				offset: 0;
-				yourself)
-		destination:
-			(SDL_GPUTextureRegion new
-				texture: gpuTexture;
-				w: aForm width;
-				h: aForm height;
-				d: 1;
-				yourself)
-		cycle: false.
-	copyPass end.
-	self ffiLibrary assertSuccess: commandBuffer submit.
+	commandBuffer copyPassDo: [ :copyPass |
+		copyPass
+			uploadTexture:
+				(SDL3GPUTextureTransferInfo new
+					transferBuffer: transferBuffer;
+					offset: 0;
+					yourself)
+			destination:
+				(SDL3GPUTextureRegion new
+					texture: gpuTexture;
+					w: aForm width;
+					h: aForm height;
+					d: 1;
+					yourself)
+			cycle: false ].
+	commandBuffer submit.
 
-	self releaseGPUTransferBuffer: transferBuffer.
+	transferBuffer release.
 	
 	^ gpuTexture
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDevice >> newGraphicsPipeline: aBlock [
+
+	| info |
+	info := SDL3GPUGraphicsPipelineCreateInfo externalNew.
+	^ [ 
+		aBlock value: info.
+		(self ffiLibrary newGPUGraphicsPipelineDevice: self createinfo: info)
+			assertNotNullReturn;
+			device: self;
+			yourself
+	] ensure: [ info free ]
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDevice >> newSampler: aBlock [
+
+	| info |
+	info := SDL3GPUSamplerCreateInfo externalNew.
+	^ [ 
+		aBlock value: info.
+		(self ffiLibrary newGPUSamplerDevice: self createinfo: info)
+			assertNotNullReturn;
+			device: self;
+			yourself
+	] ensure: [ info free ]
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDevice >> newTexture: aBlock [
+
+	| info |
+	info := SDL3GPUTextureCreateInfo externalNew.
+	^ [ 
+		aBlock value: info.
+		(self ffiLibrary newGPUTextureDevice: self createinfo: info)
+			assertNotNullReturn;
+			device: self;
+			yourself
+	] ensure: [ info free ]
 ]
 
 { #category : '*SDL3-Own' }
 SDL3GPUDevice >> newUploadTransferBuffer: size [
 	"Create a transfer buffer for uploading data to the GPU."
 
-	| createinfo transferBuffer |
-	createinfo := SDL3GPUTransferBufferCreateInfo new.
-	createinfo
-		usage: SDL3GPUTransferBufferUsage upload;
-		size: size;
-		props: 0.
-
-	transferBuffer := self newGPUTransferBufferCreateinfo: createinfo.
-	^ transferBuffer
+	| info |
+	info := SDL3GPUTransferBufferCreateInfo externalNew.
+	^ [
+	 	info
+			usage: SDL3GPUTransferBufferUsage upload;
+			size: size;
+			props: 0.
+		(self ffiLibrary newGPUTransferBufferDevice: self createinfo: info)
+			assertNotNullReturn;
+			device: self;
+			yourself
+	] ensure: [ info free ]
 ]
 
 { #category : '*SDL3-Own' }
@@ -146,6 +259,13 @@ SDL3GPUDevice class >> unsafeNewWithProperties: propertiesID [
 	^ (self ffiLibrary newGPUDeviceWithProperties: propertiesID)
 		  assertNotNullReturn;
 		  yourself
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUDevice >> uploadToGPUDo: aBlock [
+	"Acquires a command buffer, starts a copy pass, yields an uploader for batching, and submits the commands."
+
+	SDL3GPUUploader on: self do: aBlock
 ]
 
 { #category : '*SDL3-Own' }

--- a/src/SDL3-Own/SDL3GPUGraphicsPipelineCreateInfo.extension.st
+++ b/src/SDL3-Own/SDL3GPUGraphicsPipelineCreateInfo.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'SDL3GPUGraphicsPipelineCreateInfo' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUGraphicsPipelineCreateInfo >> vertex: vShader fragment: fShader targets: targetArray [
+
+	vShader ifNotNil: [ self vertexShader: vShader ].
+	fShader ifNotNil: [ self fragmentShader: fShader ].
+	self targetInfo colorDescriptions: targetArray
+]

--- a/src/SDL3-Own/SDL3GPUGraphicsPipelineTargetInfo.extension.st
+++ b/src/SDL3-Own/SDL3GPUGraphicsPipelineTargetInfo.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'SDL3GPUGraphicsPipelineTargetInfo' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUGraphicsPipelineTargetInfo >> colorDescriptions: descArray [
+
+	self
+		colorTargetDescriptions: descArray;
+		numColorTargets: descArray size
+]

--- a/src/SDL3-Own/SDL3GPURenderPass.extension.st
+++ b/src/SDL3-Own/SDL3GPURenderPass.extension.st
@@ -1,64 +1,80 @@
 Extension { #name : 'SDL3GPURenderPass' }
 
 { #category : '*SDL3-Own' }
-SDL3GPURenderPass >> bindGPUFragmentSamplersFirstSlot: firstSlot textureSamplerBindings: textureSamplerBindings [
+SDL3GPURenderPass >> fragmentSamplers: textureSamplerBindings slot: firstSlot [
 
 	^ self
-		 bindGPUFragmentSamplersFirstSlot: firstSlot
-		 textureSamplerBindings: (textureSamplerBindings ifEmpty: [ ExternalAddress null ])
-		 numBindings: textureSamplerBindings size
+		 fragmentSamplersSlot: firstSlot
+		 bindings: (textureSamplerBindings ifEmpty: [ ExternalAddress null ])
+		 count: textureSamplerBindings size
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPURenderPass >> bindGPUFragmentStorageBuffersFirstSlot: firstSlot storageBuffers: storageBuffers [
+SDL3GPURenderPass >> fragmentStorageBuffers: storageBuffers slot: firstSlot [
 
 	^ self
-		 bindGPUFragmentStorageBuffersFirstSlot: firstSlot
-		 storageBuffers: (storageBuffers ifEmpty: [ ExternalAddress null ])
-		 numBindings: storageBuffers size
+		 fragmentStorageBuffersSlot: firstSlot
+		 bindings: (storageBuffers ifEmpty: [ ExternalAddress null ])
+		 count: storageBuffers size
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPURenderPass >> bindGPUFragmentStorageTexturesFirstSlot: firstSlot storageTextures: storageTextures [
+SDL3GPURenderPass >> fragmentStorageTextures: storageTextures slot: firstSlot [
 
 	^ self
-		 bindGPUFragmentStorageTexturesFirstSlot: firstSlot
-		 storageTextures: (storageTextures ifEmpty: [ ExternalAddress null ])
-		 numBindings: storageTextures size
+		 fragmentStorageTexturesSlot: firstSlot
+		 bindings: (storageTextures ifEmpty: [ ExternalAddress null ])
+		 count: storageTextures size
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPURenderPass >> bindGPUVertexBuffersFirstSlot: firstSlot bindings: bindings [
+SDL3GPURenderPass >> indexBuffer16Bit: aBinding [
 
-	^ self
-		 bindGPUVertexBuffersFirstSlot: firstSlot
-		 bindings: (bindings ifEmpty: [ ExternalAddress null ])
-		 numBindings: bindings size
+	self
+		indexBuffer: aBinding
+		elementSize: SDL3GPUIndexElementSize at16bit
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPURenderPass >> bindGPUVertexSamplersFirstSlot: firstSlot textureSamplerBindings: textureSamplerBindings [
+SDL3GPURenderPass >> indexBuffer32Bit: aBinding [
 
-	^ self
-		 bindGPUVertexSamplersFirstSlot: firstSlot
-		 textureSamplerBindings: (textureSamplerBindings ifEmpty: [ ExternalAddress null ])
-		 numBindings: textureSamplerBindings size
+	self
+		indexBuffer: aBinding
+		elementSize: SDL3GPUIndexElementSize at32bit
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPURenderPass >> bindGPUVertexStorageBuffersFirstSlot: firstSlot storageBuffers: storageBuffers [
+SDL3GPURenderPass >> vertexBuffers: anArray slot: firstSlot [
 
 	^ self
-		 bindGPUVertexStorageBuffersFirstSlot: firstSlot
-		 storageBuffers: (storageBuffers ifEmpty: [ ExternalAddress null ])
-		 numBindings: storageBuffers size
+		 vertexBuffersSlot: firstSlot
+		 bindings: (anArray ifEmpty: [ ExternalAddress null ])
+		 count: anArray size
 ]
 
 { #category : '*SDL3-Own' }
-SDL3GPURenderPass >> bindGPUVertexStorageTexturesFirstSlot: firstSlot storageTextures: storageTextures [
+SDL3GPURenderPass >> vertexSamplers: textureSamplerBindings slot: firstSlot [
 
 	^ self
-		 bindGPUVertexStorageTexturesFirstSlot: firstSlot
-		 storageTextures: (storageTextures ifEmpty: [ ExternalAddress null ])
-		 numBindings: storageTextures size
+		 vertexSamplersSlot: firstSlot
+		 bindings: (textureSamplerBindings ifEmpty: [ ExternalAddress null ])
+		 count: textureSamplerBindings size
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPURenderPass >> vertexStorageBuffers: storageBuffers slot: firstSlot [
+
+	^ self
+		 vertexStorageBuffersSlot: firstSlot
+		 bindings: (storageBuffers ifEmpty: [ ExternalAddress null ])
+		 count: storageBuffers size
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPURenderPass >> vertexStorageTextures: storageTextures slot: firstSlot [
+
+	^ self
+		 vertexStorageTexturesSlot: firstSlot
+		 bindings: (storageTextures ifEmpty: [ ExternalAddress null ])
+		 count: storageTextures size
 ]

--- a/src/SDL3-Own/SDL3GPURenderState.extension.st
+++ b/src/SDL3-Own/SDL3GPURenderState.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : 'SDL3GPURenderState' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPURenderState >> pushFragmentUniform: data slot: slot [
+
+	^ self
+		  fragmentUniformsSlotIndex: slot
+		  data: data
+		  length: data class structureSize
+]

--- a/src/SDL3-Own/SDL3GPUStorageBufferReadWriteBinding.extension.st
+++ b/src/SDL3-Own/SDL3GPUStorageBufferReadWriteBinding.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : 'SDL3GPUStorageBufferReadWriteBinding' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageBufferReadWriteBinding >> beBuffer: aBuffer [
+
+	self
+		buffer: aBuffer;
+		cycle: false
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageBufferReadWriteBinding class >> buffer: aBuffer [
+
+	^ self safeNew
+		beBuffer: aBuffer;
+		yourself
+]

--- a/src/SDL3-Own/SDL3GPUStorageTextureReadWriteBinding.extension.st
+++ b/src/SDL3-Own/SDL3GPUStorageTextureReadWriteBinding.extension.st
@@ -1,0 +1,57 @@
+Extension { #name : 'SDL3GPUStorageTextureReadWriteBinding' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageTextureReadWriteBinding >> beTexture: aTexture [
+
+	self beTexture: aTexture cycle: false
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageTextureReadWriteBinding >> beTexture: aTexture cycle: aBoolean [
+
+	self
+		texture: aTexture;
+		mipLevel: 0;
+		layer: 0;
+		cycle: aBoolean
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageTextureReadWriteBinding >> beUnbound [
+
+	self beUnboundCycle: false
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageTextureReadWriteBinding >> beUnboundCycle: aBoolean [
+
+	self beTexture: ExternalAddress null cycle: aBoolean
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageTextureReadWriteBinding class >> texture: aTexture [
+
+	^ self texture: aTexture cycle: false
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageTextureReadWriteBinding class >> texture: aTexture cycle: aBoolean [
+
+	^ self safeNew
+		beTexture: aTexture cycle: aBoolean;
+		yourself
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageTextureReadWriteBinding class >> unbound [
+
+	^ self unboundCycle: false
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUStorageTextureReadWriteBinding class >> unboundCycle: aBoolean [
+
+	^ self safeNew
+		beUnboundCycle: aBoolean;
+		yourself
+]

--- a/src/SDL3-Own/SDL3GPUTextureSamplerBinding.extension.st
+++ b/src/SDL3-Own/SDL3GPUTextureSamplerBinding.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : 'SDL3GPUTextureSamplerBinding' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUTextureSamplerBinding >> beTexture: aTexture sampler: aSampler [
+
+	self
+		texture: aTexture;
+		sampler: aSampler
+]
+
+{ #category : '*SDL3-Own' }
+SDL3GPUTextureSamplerBinding class >> texture: aTexture sampler: aSampler [
+
+	^ self safeNew
+		beTexture: aTexture sampler: aSampler;
+		yourself
+]

--- a/src/SDL3-Own/SDL3GPUUploader.class.st
+++ b/src/SDL3-Own/SDL3GPUUploader.class.st
@@ -1,0 +1,199 @@
+"
+I provide a builder-style API to simplify uploading data to GPU buffers.
+I orchestrate the creation, mapping, unmapping, and release of transfer buffers, and automatically record the upload commands to my associated copy pass.
+
+My API automatically calculates byte sizes based on the provided FFI types and sizes.
+
+Instance Variables:
+	gpuDevice	<SDL3GPUDevice>
+	copyPass	<SDL3GPUCopyPass>
+"
+Class {
+	#name : 'SDL3GPUUploader',
+	#superclass : 'Object',
+	#instVars : [
+		'gpuDevice',
+		'copyPass'
+	],
+	#pools : [
+		'SDL3Typedef',
+		'SDL3ZConstants'
+	],
+	#category : 'SDL3-Own-GPU',
+	#package : 'SDL3-Own',
+	#tag : 'GPU'
+}
+
+{ #category : 'instance creation' }
+SDL3GPUUploader class >> on: aGPUDevice copyPass: aCopyPass do: aBlock [
+	"Yields an uploader using an already active copy pass."
+
+	| uploader |
+	uploader := self new
+		            gpuDevice: aGPUDevice;
+		            copyPass: aCopyPass;
+		            yourself.
+	aBlock value: uploader
+]
+
+{ #category : 'instance creation' }
+SDL3GPUUploader class >> on: aGPUDevice do: aBlock [
+	"Acquires a command buffer, starts a copy pass, yields an uploader for batching, and submits the commands."
+
+	| commandBuffer |
+	commandBuffer := aGPUDevice acquireGPUCommandBuffer.
+	[
+		commandBuffer copyPassDo: [ :pass |
+			self on: aGPUDevice copyPass: pass do: aBlock ]
+	] ifCurtailed: [ commandBuffer cancel ].
+	commandBuffer submit
+]
+
+{ #category : 'accessing' }
+SDL3GPUUploader >> copyPass: anObject [
+
+	copyPass := anObject
+]
+
+{ #category : 'accessing' }
+SDL3GPUUploader >> gpuDevice: anObject [
+
+	gpuDevice := anObject
+]
+
+{ #category : 'uploading' }
+SDL3GPUUploader >> transferBuffer: aTransferBuffer uploadTo: targetBuffer type: ffiClass count: arraySize cycle: cycleBoolean fillWith: aBlock [
+	"Uses the provided transferBuffer (user-managed), maps it as an FFIArray of the given type, passes it to aBlock for filling, and records the upload command. Does NOT release the transfer buffer."
+
+	| byteSize |
+	byteSize := ffiClass externalTypeSize * arraySize.
+	
+	gpuDevice mapTransferBuffer: aTransferBuffer cycle: cycleBoolean do: [ :mappedAddress |
+		| mappedArray |
+		mappedArray := FFIArray fromHandle: mappedAddress type: ffiClass size: arraySize.
+		aBlock value: mappedArray ].
+
+	copyPass
+		uploadBuffer:
+			(SDL_GPUTransferBufferLocation new
+				transferBuffer: aTransferBuffer;
+				offset: 0;
+				yourself)
+		destination:
+			(SDL_GPUBufferRegion new
+				buffer: targetBuffer;
+				offset: 0;
+				size: byteSize;
+				yourself)
+		cycle: cycleBoolean
+]
+
+{ #category : 'uploading' }
+SDL3GPUUploader >> transferBuffer: aTransferBuffer uploadTo: targetBuffer type: ffiClass count: arraySize cycle: cycleBoolean fromPointer: sourceAddress [
+	"Uses the provided transferBuffer (user-managed) and directly memCopies the data from sourceAddress. Does NOT release the transfer buffer."
+
+	| byteSize |
+	byteSize := ffiClass externalTypeSize * arraySize.
+	
+	gpuDevice mapTransferBuffer: aTransferBuffer cycle: cycleBoolean do: [ :mappedAddress |
+		LibC memCopy: sourceAddress to: mappedAddress size: byteSize ].
+
+	copyPass
+		uploadBuffer:
+			(SDL_GPUTransferBufferLocation new
+				transferBuffer: aTransferBuffer;
+				offset: 0;
+				yourself)
+		destination:
+			(SDL_GPUBufferRegion new
+				buffer: targetBuffer;
+				offset: 0;
+				size: byteSize;
+				yourself)
+		cycle: cycleBoolean
+]
+
+{ #category : 'uploading' }
+SDL3GPUUploader >> uploadTexture: aGPUTexture fromPointer: sourceAddress byteSize: byteSize w: width h: height cycle: cycleBoolean [
+	"Uploads pixel data from a raw pointer to a texture. Automatically manages a temporary transfer buffer."
+
+	| transferBuffer |
+	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
+	[
+		gpuDevice mapTransferBuffer: transferBuffer cycle: cycleBoolean do: [ :mappedAddress |
+			LibC memCopy: sourceAddress to: mappedAddress size: byteSize ].
+
+		copyPass
+			uploadTexture:
+				(SDL3GPUTextureTransferInfo new
+					transferBuffer: transferBuffer;
+					offset: 0;
+					yourself)
+			destination:
+				(SDL3GPUTextureRegion new
+					texture: aGPUTexture;
+					w: width;
+					h: height;
+					d: 1;
+					yourself)
+			cycle: cycleBoolean
+	] ensure: [ transferBuffer release ]
+]
+
+{ #category : 'uploading' }
+SDL3GPUUploader >> uploadTo: targetBuffer type: ffiClass count: arraySize cycle: cycleBoolean fillWith: aBlock [
+	"Creates a transfer buffer, maps it as an FFIArray of the given type, passes it to aBlock for filling, records the upload command, and safely cleans up."
+
+	| byteSize transferBuffer |
+	byteSize := ffiClass externalTypeSize * arraySize.
+	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
+	
+	[
+		gpuDevice mapTransferBuffer: transferBuffer cycle: cycleBoolean do: [ :mappedAddress |
+			| mappedArray |
+			mappedArray := FFIArray fromHandle: mappedAddress type: ffiClass size: arraySize.
+			aBlock value: mappedArray ].
+
+		copyPass
+			uploadBuffer:
+				(SDL_GPUTransferBufferLocation new
+					transferBuffer: transferBuffer;
+					offset: 0;
+					yourself)
+			destination:
+				(SDL_GPUBufferRegion new
+					buffer: targetBuffer;
+					offset: 0;
+					size: byteSize;
+					yourself)
+			cycle: cycleBoolean
+	] ensure: [ transferBuffer release ]
+]
+
+{ #category : 'uploading' }
+SDL3GPUUploader >> uploadTo: targetBuffer type: ffiClass count: arraySize cycle: cycleBoolean fromPointer: sourceAddress [
+	"A fast-path that creates a transfer buffer and directly memCopies the data from sourceAddress."
+
+	| byteSize transferBuffer |
+	byteSize := ffiClass externalTypeSize * arraySize.
+	transferBuffer := gpuDevice newUploadTransferBuffer: byteSize.
+	
+	[
+		gpuDevice mapTransferBuffer: transferBuffer cycle: cycleBoolean do: [ :mappedAddress |
+			LibC memCopy: sourceAddress to: mappedAddress size: byteSize ].
+
+		copyPass
+			uploadBuffer:
+				(SDL_GPUTransferBufferLocation new
+					transferBuffer: transferBuffer;
+					offset: 0;
+					yourself)
+			destination:
+				(SDL_GPUBufferRegion new
+					buffer: targetBuffer;
+					offset: 0;
+					size: byteSize;
+					yourself)
+			cycle: cycleBoolean
+	] ensure: [ transferBuffer release ]
+]

--- a/src/SDL3-Own/SDL3GPUVertexInputState.extension.st
+++ b/src/SDL3-Own/SDL3GPUVertexInputState.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : 'SDL3GPUVertexInputState' }
+
+{ #category : '*SDL3-Own' }
+SDL3GPUVertexInputState >> attributes: attrArray bindings: bindArray [
+
+	self
+		vertexAttributes: attrArray;
+		numVertexAttributes: attrArray size;
+		vertexBufferDescriptions: bindArray;
+		numVertexBuffers: bindArray size
+]

--- a/src/SDL3-Own/SDL3GraphicsShaderSource.class.st
+++ b/src/SDL3-Own/SDL3GraphicsShaderSource.class.st
@@ -36,7 +36,12 @@ SDL3GraphicsShaderSource class >> newShaderAmong: supportedShaderFormats device:
 				numStorageBuffers: self numberOfReadOnlyStorageBuffers + self numberOfReadWriteStorageBuffers;
 				numStorageTextures: self numberOfReadOnlyStorageTextures + self numberOfReadWriteStorageTextures.
 
-			shader := aSDL3GPUDevice newGPUShaderCreateinfo: createInfo.
+			shader := (aSDL3GPUDevice ffiLibrary
+				newGPUShaderDevice: aSDL3GPUDevice
+				createinfo: createInfo)
+					assertNotNullReturn;
+					device: aSDL3GPUDevice;
+					yourself.
 			^ shader ]
 ]
 

--- a/src/SDL3-Own/SDL3Point.extension.st
+++ b/src/SDL3-Own/SDL3Point.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : 'SDL3Point' }
+
+{ #category : '*SDL3-Own' }
+SDL3Point >> beX: x y: y [
+
+	self
+		x: x;
+		y: y
+]

--- a/src/SDL3-Own/SDL3Renderer.extension.st
+++ b/src/SDL3-Own/SDL3Renderer.extension.st
@@ -19,6 +19,22 @@ SDL3Renderer >> logicalPresentationRect [
 ]
 
 { #category : '*SDL3-Own' }
+SDL3Renderer >> newRenderState: aBlock [
+
+	| info |
+	info := SDL3GPURenderStateCreateInfo externalNew.
+	^ [
+		aBlock value: info. 
+		(self ffiLibrary
+			newGPURenderStateRenderer: self
+			createinfo: info)
+			assertNotNullReturn;
+			device: self gpuDevice;
+			yourself
+		] ensure: [ info free ]
+]
+
+{ #category : '*SDL3-Own' }
 SDL3Renderer >> newTextureFromForm: aForm [
 	"Answer a new `SDL_Texture`. The form pixels will be uploaded to the new texture, assuming form depth is 32 bits. Sender is responsible of destroying the texture."
 

--- a/src/SDL3-Tests/SDL3GPUBasicTest.class.st
+++ b/src/SDL3-Tests/SDL3GPUBasicTest.class.st
@@ -3,49 +3,11 @@ I am a base test for the SDL3 GPU API.
 "
 Class {
 	#name : 'SDL3GPUBasicTest',
-	#superclass : 'SDL3Test',
-	#instVars : [
-		'window',
-		'gpuDevice'
-	],
+	#superclass : 'SDL3GPUTest',
 	#category : 'SDL3-Tests-Library',
 	#package : 'SDL3-Tests',
 	#tag : 'Library'
 }
-
-{ #category : 'running' }
-SDL3GPUBasicTest >> setUp [
-
-	super setUp.
-	sdl := LibSDL3 uniqueInstance.
-	sdl init: SDL_INIT_VIDEO.
-	window := SDL3Window
-		         unsafeNewTitle: 'GPU Test'
-		         w: 640
-		         h: 480
-		         flags: 0.
-
-	gpuDevice := SDL3GPUDevice
-		            unsafeNewFormatFlags:
-			            SDL_GPU_SHADERFORMAT_DXIL
-			            | SDL_GPU_SHADERFORMAT_MSL
-			            | SDL_GPU_SHADERFORMAT_SPIRV
-		            debugMode: true
-		            name: nil.
-
-	gpuDevice claimWindow: window
-]
-
-{ #category : 'running' }
-SDL3GPUBasicTest >> tearDown [
-
-	gpuDevice ifNotNil: [
-		gpuDevice releaseWindow: window.
-		gpuDevice destroy ].
-	window ifNotNil: [ window destroy ].
-
-	super tearDown
-]
 
 { #category : 'tests' }
 SDL3GPUBasicTest >> test01AcquireAndCancelCommandBuffer [
@@ -64,10 +26,8 @@ SDL3GPUBasicTest >> test02AcquireSwapchainTextureAndSubmitEmpty [
 	textureHolder := (FFIExternalValueHolder ofType: SDL_GPUTexture) new.
 	
 	commandBuffer
-		waitAndAcquireGPUSwapchainTextureForWindow: window
-		into: textureHolder
-		width: nil
-		height: nil.
+		waitAndAcquireSwapchainTextureForWindow: window
+		into: textureHolder width: nil height: nil.
 		
 	self deny: textureHolder value isNull.
 
@@ -77,32 +37,23 @@ SDL3GPUBasicTest >> test02AcquireSwapchainTextureAndSubmitEmpty [
 { #category : 'tests' }
 SDL3GPUBasicTest >> test03ClearColorInRenderPass [
 
-	| commandBuffer textureHolder renderPass colorTargetInfos |
+	| commandBuffer textureHolder colorTargetInfos |
 	commandBuffer := gpuDevice acquireGPUCommandBuffer.
 
 	textureHolder := (FFIExternalValueHolder ofType: SDL_GPUTexture) new.
 	
 	commandBuffer
-		waitAndAcquireGPUSwapchainTextureForWindow: window
-		into: textureHolder
-		width: nil
-		height: nil.
+		waitAndAcquireSwapchainTextureForWindow: window
+		into: textureHolder width: nil height: nil.
 	
 	self deny: textureHolder value isNull.
 	
-	colorTargetInfos := FFIExternalArray externalNewType: SDL_GPUColorTargetInfo size: 1.
-	colorTargetInfos autoRelease.
+	colorTargetInfos := SDL_GPUColorTargetInfo safeNewArray: 1.
 	colorTargetInfos first
-		texture: textureHolder value;
-		storeOp: SDL_GPU_STOREOP_STORE;
-		loadOp: SDL_GPU_LOADOP_CLEAR;
-		updateClearColorFrom: Color yellow.
+		beClearTexture: textureHolder value
+		color: Color yellow.
 
-	renderPass := commandBuffer
-		beginGPURenderPassColorTargetInfos: colorTargetInfos
-		depthStencilTargetInfo: nil.
-		renderPass end.
-
+	commandBuffer renderPassTargets: colorTargetInfos do: [ :renderPass | ].
+		
 	commandBuffer submit
-
 ]

--- a/src/SDL3-Tests/SDL3GPUDownloadTest.class.st
+++ b/src/SDL3-Tests/SDL3GPUDownloadTest.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : 'SDL3GPUDownloadTest',
+	#superclass : 'SDL3GPUTest',
+	#category : 'SDL3-Tests-Library',
+	#package : 'SDL3-Tests',
+	#tag : 'Library'
+}
+
+{ #category : 'tests' }
+SDL3GPUDownloadTest >> test01DownloadFromGPUDeviceExtension [
+
+	| count byteSize targetBuffer sourceArray resultData |
+	count := 1024.
+	byteSize := count * FFIFloat32 externalTypeSize.
+	targetBuffer :=
+		gpuDevice
+			newGPUBufferUsage:
+				SDL_GPU_BUFFERUSAGE_VERTEX | SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ
+			size: byteSize.
+	
+	sourceArray := FFIArray newType: FFIFloat32 size: count.
+	1 to: count do: [ :i | sourceArray at: i put: i asFloat ].
+	
+	[
+		"1. Upload data to test buffer"
+		gpuDevice uploadToGPUDo: [ :uploader |
+			uploader 
+				uploadTo: targetBuffer 
+				type: FFIFloat32 
+				count: count 
+				cycle: false 
+				fromPointer: sourceArray ].
+				
+		"2. Download and verify"
+		gpuDevice
+			downloadFrom: targetBuffer
+			type: FFIFloat32
+			count: count do: [ :downloadedArray |
+				resultData := FFIArray newType: FFIFloat32 size: count.
+				LibC memCopy: downloadedArray to: resultData size: byteSize ].
+	] ensure: [ targetBuffer release ].
+
+	1 to: count do: [ :i | self assert: (resultData at: i) equals: i asFloat ]
+]

--- a/src/SDL3-Tests/SDL3GPUTest.class.st
+++ b/src/SDL3-Tests/SDL3GPUTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : 'SDL3GPUTest',
+	#superclass : 'SDL3Test',
+	#instVars : [
+		'window',
+		'gpuDevice'
+	],
+	#category : 'SDL3-Tests-Library',
+	#package : 'SDL3-Tests',
+	#tag : 'Library'
+}
+
+{ #category : 'testing' }
+SDL3GPUTest class >> isAbstract [
+
+	^ self == SDL3GPUTest
+]
+
+{ #category : 'running' }
+SDL3GPUTest >> setUp [
+
+	super setUp.
+	sdl := LibSDL3 uniqueInstance.
+	sdl init: SDL_INIT_VIDEO.
+	window := SDL3Window
+		         unsafeNewTitle: 'GPU Test'
+		         w: 640
+		         h: 480
+		         flags: 0.
+
+	gpuDevice := SDL3GPUDevice
+		            unsafeNewFormatFlags:
+			            SDL_GPU_SHADERFORMAT_DXIL
+			            | SDL_GPU_SHADERFORMAT_MSL
+			            | SDL_GPU_SHADERFORMAT_SPIRV
+		            debugMode: true
+		            name: nil.
+
+	gpuDevice claimWindow: window
+]
+
+{ #category : 'running' }
+SDL3GPUTest >> tearDown [
+
+	gpuDevice ifNotNil: [
+		gpuDevice releaseWindow: window.
+		gpuDevice destroy ].
+	window ifNotNil: [ window destroy ].
+
+	super tearDown
+]

--- a/src/SDL3-Tests/SDL3GPUUploadTest.class.st
+++ b/src/SDL3-Tests/SDL3GPUUploadTest.class.st
@@ -1,0 +1,64 @@
+Class {
+	#name : 'SDL3GPUUploadTest',
+	#superclass : 'SDL3GPUTest',
+	#category : 'SDL3-Tests-Library',
+	#package : 'SDL3-Tests',
+	#tag : 'Library'
+}
+
+{ #category : 'tests' }
+SDL3GPUUploadTest >> test01UploadToGPUDeviceExtension [
+
+	| byteSize targetBuffer |
+	byteSize := 1024 * FFIFloat32 externalTypeSize.
+	targetBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX size: byteSize.
+	
+	[	gpuDevice uploadToGPUDo: [ :uploader |
+			uploader 
+				uploadTo: targetBuffer 
+				type: FFIFloat32 
+				count: 1024 
+				cycle: false 
+				fillWith: [ :array | 1 to: 1024 do: [ :i | array at: i put: i asFloat ] ] ]
+	] ensure: [ targetBuffer release ]
+]
+
+{ #category : 'tests' }
+SDL3GPUUploadTest >> test02UploadFromPointer [
+
+	| byteSize targetBuffer sourceArray |
+	byteSize := 1024 * FFIFloat32 externalTypeSize.
+	targetBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX size: byteSize.
+	
+	sourceArray := FFIArray newType: FFIFloat32 size: 1024.
+	1 to: 1024 do: [ :i | sourceArray at: i put: i asFloat ].
+	
+	[	gpuDevice uploadToGPUDo: [ :uploader |
+			uploader 
+				uploadTo: targetBuffer 
+				type: FFIFloat32 
+				count: 1024 
+				cycle: false 
+				fromPointer: sourceArray ]
+	] ensure: [ targetBuffer release ]
+]
+
+{ #category : 'tests' }
+SDL3GPUUploadTest >> test03UploadToGPUCommandBufferExtension [
+
+	| byteSize targetBuffer commandBuffer |
+	byteSize := 1024 * FFIFloat32 externalTypeSize.
+	targetBuffer := gpuDevice newGPUBufferUsage: SDL_GPU_BUFFERUSAGE_VERTEX size: byteSize.
+	
+	commandBuffer := gpuDevice acquireGPUCommandBuffer.
+	[
+		commandBuffer uploadToGPUDo: [ :uploader |
+			uploader 
+				uploadTo: targetBuffer 
+				type: FFIFloat32 
+				count: 1024 
+				cycle: false 
+				fillWith: [ :array | 1 to: 1024 do: [ :i | array at: i put: i asFloat ] ] ].
+		commandBuffer submit.
+	] ensure: [ targetBuffer release ]
+]

--- a/src/SDL3/SDL3GPUBuffer.class.st
+++ b/src/SDL3/SDL3GPUBuffer.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUBuffer',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUColorTargetBlendState.class.st
+++ b/src/SDL3/SDL3GPUColorTargetBlendState.class.st
@@ -37,6 +37,20 @@ SDL3GPUColorTargetBlendState class >> fieldsDesc [
 	)
 ]
 
+{ #category : 'instance creation' }
+SDL3GPUColorTargetBlendState class >> newAlphaBlend [
+
+	^ self new
+		  enableBlend: true;
+		  srcColorBlendfactor: SDL3GPUBlendFactor srcAlpha;
+		  dstColorBlendfactor: SDL3GPUBlendFactor oneMinusSrcAlpha;
+		  colorBlendOp: SDL3GPUBlendOp add;
+		  srcAlphaBlendfactor: SDL3GPUBlendFactor srcAlpha;
+		  dstAlphaBlendfactor: SDL3GPUBlendFactor oneMinusSrcAlpha;
+		  alphaBlendOp: SDL3GPUBlendOp add;
+		  yourself
+]
+
 { #category : 'accessing - structure variables' }
 SDL3GPUColorTargetBlendState >> alphaBlendOp [
 	"This method was automatically generated"

--- a/src/SDL3/SDL3GPUCommandBuffer.class.st
+++ b/src/SDL3/SDL3GPUCommandBuffer.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUCommandBuffer',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUComputePass.class.st
+++ b/src/SDL3/SDL3GPUComputePass.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUComputePass',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUComputePipeline.class.st
+++ b/src/SDL3/SDL3GPUComputePipeline.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUComputePipeline',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUCopyPass.class.st
+++ b/src/SDL3/SDL3GPUCopyPass.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUCopyPass',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUDeviceObject.class.st
+++ b/src/SDL3/SDL3GPUDeviceObject.class.st
@@ -1,0 +1,41 @@
+"
+I represent an object that belongs to a \`SDL3GPUDevice\`.
+
+In SDL 3.4.0, several objects are created and released with a GPU device, showing an ownership relation.
+"
+Class {
+	#name : 'SDL3GPUDeviceObject',
+	#superclass : 'SDL3BaseObject',
+	#instVars : [
+		'device'
+	],
+	#category : 'SDL3',
+	#package : 'SDL3'
+}
+
+{ #category : 'accessing' }
+SDL3GPUDeviceObject >> device [
+
+	^ device
+]
+
+{ #category : 'initialization' }
+SDL3GPUDeviceObject >> device: aSDL3GPUDevice [
+
+	device := aSDL3GPUDevice
+]
+
+{ #category : 'releasing' }
+SDL3GPUDeviceObject >> release [
+	"Releases the receiver from its owning device. If the device is nil or the handle is already null, does nothing."
+
+	(device isNil or: [ self isNull ]) ifTrue: [ ^ self ].
+	self releaseFromGPUDevice
+]
+
+{ #category : 'releasing' }
+SDL3GPUDeviceObject >> releaseFromGPUDevice [
+	"Should be overridden by subclasses to send the specific release message to the owning device."
+
+	self subclassResponsibility
+]

--- a/src/SDL3/SDL3GPUFence.class.st
+++ b/src/SDL3/SDL3GPUFence.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUFence',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUGraphicsPipeline.class.st
+++ b/src/SDL3/SDL3GPUGraphicsPipeline.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUGraphicsPipeline',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPURenderPass.class.st
+++ b/src/SDL3/SDL3GPURenderPass.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPURenderPass',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPURenderState.class.st
+++ b/src/SDL3/SDL3GPURenderState.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPURenderState',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUSampler.class.st
+++ b/src/SDL3/SDL3GPUSampler.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUSampler',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUShader.class.st
+++ b/src/SDL3/SDL3GPUShader.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUShader',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUTexture.class.st
+++ b/src/SDL3/SDL3GPUTexture.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUTexture',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3GPUTransferBuffer.class.st
+++ b/src/SDL3/SDL3GPUTransferBuffer.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : 'SDL3GPUTransferBuffer',
-	#superclass : 'SDL3BaseObject',
+	#superclass : 'SDL3GPUDeviceObject',
 	#category : 'SDL3-Base',
 	#package : 'SDL3',
 	#tag : 'Base'

--- a/src/SDL3/SDL3Structure.class.st
+++ b/src/SDL3/SDL3Structure.class.st
@@ -11,3 +11,19 @@ Class {
 	#package : 'SDL3',
 	#tag : 'Base'
 }
+
+{ #category : 'instance creation' }
+SDL3Structure class >> safeNew [
+
+	^ self externalNew
+		autoRelease;
+		yourself
+]
+
+{ #category : 'instance creation' }
+SDL3Structure class >> safeNewArray: anInteger [
+
+	^ (FFIExternalArray externalNewType: self size: anInteger)
+		autoRelease;
+		yourself
+]


### PR DESCRIPTION
- GPU API: Convert SDL3 instance creation API that received "create info" transient object now receive a BlockClosure so the sender can set up more easily
- Add SDL3GPUDeviceObject: SDL3 GPU objects such as SDL_GPUCommandBuffer lack a reference to their owner SDL_GPUDevice. This allows simpler #release
- The #safeNew and #safeNewArray: new API helps to create external objects that #autoRelease.
- Upload and download API to help reducing boilerplate and error prone code
- Add #newAlphaBlend to create a commonly used color target blend state
- Add new "#beXX:"  extension methods which should ease setup structs
- SDL3 GPU: many renames to simplify them
- Remove some uneeded spaces
- Use #first instead of  "at: 1", etc.